### PR TITLE
Implement backend demo mode

### DIFF
--- a/ve-shop-backend/.env.example
+++ b/ve-shop-backend/.env.example
@@ -1,0 +1,13 @@
+APP_NAME=Laravel
+APP_ENV=local
+APP_KEY=
+APP_DEBUG=true
+APP_URL=http://localhost
+
+LOG_CHANNEL=stack
+LOG_LEVEL=debug
+
+DB_CONNECTION=sqlite
+DB_DATABASE=database/database.sqlite
+
+DEMO_MODE=true

--- a/ve-shop-backend/README.md
+++ b/ve-shop-backend/README.md
@@ -59,3 +59,13 @@ If you discover a security vulnerability within Laravel, please send an e-mail t
 ## License
 
 The Laravel framework is open-sourced software licensed under the [MIT license](https://opensource.org/licenses/MIT).
+
+## Demo Mode
+
+Set `DEMO_MODE=true` in your `.env` to enable demo features. Run the following command to reset demo data:
+
+```bash
+php artisan demo:reset
+```
+
+When demo mode is active you can quickly login as a demo user by posting to `/demo-login/{role}` where `{role}` is `admin`, `vendor`, or `customer`.

--- a/ve-shop-backend/app/Http/Controllers/DemoController.php
+++ b/ve-shop-backend/app/Http/Controllers/DemoController.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\User;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class DemoController extends Controller
+{
+    public function login(Request $request, string $role): RedirectResponse
+    {
+        if (! config('app.demo')) {
+            abort(404);
+        }
+
+        $user = User::where('role', $role)->firstOrFail();
+        Auth::login($user);
+
+        return redirect('/')->with('status', 'Logged in as demo ' . $role);
+    }
+}

--- a/ve-shop-backend/app/Models/User.php
+++ b/ve-shop-backend/app/Models/User.php
@@ -21,6 +21,7 @@ class User extends Authenticatable
         'name',
         'email',
         'password',
+        'role',
     ];
 
     /**

--- a/ve-shop-backend/config/app.php
+++ b/ve-shop-backend/config/app.php
@@ -67,6 +67,8 @@ return [
 
     'timezone' => 'UTC',
 
+    'demo' => env('DEMO_MODE', false),
+
     /*
     |--------------------------------------------------------------------------
     | Application Locale Configuration

--- a/ve-shop-backend/database/migrations/0001_01_01_000003_add_role_to_users_table.php
+++ b/ve-shop-backend/database/migrations/0001_01_01_000003_add_role_to_users_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('role')->default('customer');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('role');
+        });
+    }
+};

--- a/ve-shop-backend/database/seeders/DatabaseSeeder.php
+++ b/ve-shop-backend/database/seeders/DatabaseSeeder.php
@@ -13,6 +13,11 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
+        if (config('app.demo')) {
+            $this->call(DemoSeeder::class);
+            return;
+        }
+
         // User::factory(10)->create();
 
         User::factory()->create([

--- a/ve-shop-backend/database/seeders/DemoSeeder.php
+++ b/ve-shop-backend/database/seeders/DemoSeeder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\User;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\Hash;
+
+class DemoSeeder extends Seeder
+{
+    public function run(): void
+    {
+        User::truncate();
+
+        User::create([
+            'name' => 'Demo Admin',
+            'email' => 'admin@demo.com',
+            'password' => Hash::make('password'),
+            'role' => 'admin',
+        ]);
+
+        User::create([
+            'name' => 'Demo Vendor',
+            'email' => 'vendor@demo.com',
+            'password' => Hash::make('password'),
+            'role' => 'vendor',
+        ]);
+
+        User::create([
+            'name' => 'Demo Customer',
+            'email' => 'customer@demo.com',
+            'password' => Hash::make('password'),
+            'role' => 'customer',
+        ]);
+    }
+}

--- a/ve-shop-backend/routes/console.php
+++ b/ve-shop-backend/routes/console.php
@@ -6,3 +6,17 @@ use Illuminate\Support\Facades\Artisan;
 Artisan::command('inspire', function () {
     $this->comment(Inspiring::quote());
 })->purpose('Display an inspiring quote');
+
+Artisan::command('demo:reset', function () {
+    if (!config('app.demo')) {
+        $this->error('Demo mode is not enabled.');
+        return;
+    }
+
+    $this->call('migrate:fresh', [
+        '--seed' => true,
+        '--seeder' => 'DemoSeeder',
+    ]);
+
+    $this->info('Demo data reset.');
+})->purpose('Reset the demo database state');

--- a/ve-shop-backend/routes/web.php
+++ b/ve-shop-backend/routes/web.php
@@ -1,7 +1,13 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\DemoController;
 
 Route::get('/', function () {
     return view('welcome');
 });
+
+if (config('app.demo')) {
+    Route::post('/demo-login/{role}', [DemoController::class, 'login'])
+        ->whereIn('role', ['admin', 'vendor', 'customer']);
+}

--- a/ve-shop-backend/tests/Feature/DemoModeTest.php
+++ b/ve-shop-backend/tests/Feature/DemoModeTest.php
@@ -1,0 +1,18 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Support\Facades\Hash;
+
+it('allows login as demo user', function () {
+    config(['app.demo' => true]);
+
+    $user = User::create([
+        'name' => 'Demo Admin',
+        'email' => 'admin@test.com',
+        'password' => Hash::make('password'),
+        'role' => 'admin',
+    ]);
+
+    $response = $this->post('/demo-login/admin');
+    $response->assertRedirect('/');
+});


### PR DESCRIPTION
## Summary
- add role column migration and allow mass-assign
- seed demo users when DEMO_MODE is on
- add DemoSeeder and reset command
- add DemoController with demo login route
- document demo mode usage
- provide `.env.example` for demo setup

## Testing
- `composer test` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686d014daad083309ffe1afcd068c484