### PR TITLE
Add sample API with products

### DIFF
--- a/ve-shop-backend/README.md
+++ b/ve-shop-backend/README.md
@@ -69,3 +69,4 @@ php artisan demo:reset
 ```
 
 When demo mode is active you can quickly login as a demo user by posting to `/demo-login/{role}` where `{role}` is `admin`, `vendor`, or `customer`.
+\n## API Setup\n1. Copy `.env.example` to `.env` and configure database.\n2. Run `php artisan migrate --seed` to create tables and demo data.\n3. Start the server with `php artisan serve`.\n\n### Sample request\n```bash\ncurl http://localhost:8000/api/products\n```\n

--- a/ve-shop-backend/app/Http/Controllers/Api/ProductController.php
+++ b/ve-shop-backend/app/Http/Controllers/Api/ProductController.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\StoreProductRequest;
+use App\Http\Requests\UpdateProductRequest;
+use App\Http\Resources\ProductResource;
+use App\Models\Product;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+
+class ProductController extends Controller
+{
+    public function index(): AnonymousResourceCollection
+    {
+        $products = Product::paginate();
+        return ProductResource::collection($products);
+    }
+
+    public function store(StoreProductRequest $request): ProductResource
+    {
+        $data = $request->validated();
+        if ($request->hasFile('image')) {
+            $data['image_path'] = $request->file('image')->store('products', 'public');
+        }
+        $product = Product::create($data);
+        return new ProductResource($product);
+    }
+
+    public function show(Product $product): ProductResource
+    {
+        return new ProductResource($product);
+    }
+
+    public function update(UpdateProductRequest $request, Product $product): ProductResource
+    {
+        $data = $request->validated();
+        if ($request->hasFile('image')) {
+            $data['image_path'] = $request->file('image')->store('products', 'public');
+        }
+        $product->update($data);
+        return new ProductResource($product);
+    }
+
+    public function destroy(Product $product): JsonResponse
+    {
+        $product->delete();
+        return response()->json(['message' => __('messages.deleted')]);
+    }
+}

--- a/ve-shop-backend/app/Http/Controllers/LocaleController.php
+++ b/ve-shop-backend/app/Http/Controllers/LocaleController.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\App;
+
+class LocaleController extends Controller
+{
+    public function switch(string $locale): JsonResponse
+    {
+        if (! in_array($locale, ['en', 'ar'])) {
+            return response()->json(['message' => __('messages.invalid_locale')], 422);
+        }
+
+        App::setLocale($locale);
+
+        return response()->json([
+            'message' => __('messages.locale_switched'),
+            'locale' => $locale,
+        ]);
+    }
+}

--- a/ve-shop-backend/app/Http/Middleware/SetLocale.php
+++ b/ve-shop-backend/app/Http/Middleware/SetLocale.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\App;
+
+class SetLocale
+{
+    public function handle(Request $request, Closure $next)
+    {
+        $locale = $request->input('locale') ?? $request->header('Accept-Language');
+        if ($locale) {
+            $locale = substr($locale, 0, 2);
+            if (in_array($locale, ['en', 'ar'])) {
+                App::setLocale($locale);
+            }
+        }
+        return $next($request);
+    }
+}

--- a/ve-shop-backend/app/Http/Requests/StoreProductRequest.php
+++ b/ve-shop-backend/app/Http/Requests/StoreProductRequest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreProductRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'name_en' => ['required', 'string', 'max:255'],
+            'name_ar' => ['required', 'string', 'max:255'],
+            'description_en' => ['nullable', 'string'],
+            'description_ar' => ['nullable', 'string'],
+            'price' => ['required', 'numeric', 'min:0'],
+            'stock' => ['required', 'integer', 'min:0'],
+            'image' => ['nullable', 'image'],
+        ];
+    }
+}

--- a/ve-shop-backend/app/Http/Requests/UpdateProductRequest.php
+++ b/ve-shop-backend/app/Http/Requests/UpdateProductRequest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateProductRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'name_en' => ['sometimes', 'string', 'max:255'],
+            'name_ar' => ['sometimes', 'string', 'max:255'],
+            'description_en' => ['nullable', 'string'],
+            'description_ar' => ['nullable', 'string'],
+            'price' => ['sometimes', 'numeric', 'min:0'],
+            'stock' => ['sometimes', 'integer', 'min:0'],
+            'image' => ['nullable', 'image'],
+        ];
+    }
+}

--- a/ve-shop-backend/app/Http/Resources/ProductResource.php
+++ b/ve-shop-backend/app/Http/Resources/ProductResource.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class ProductResource extends JsonResource
+{
+    public function toArray($request): array
+    {
+        $locale = app()->getLocale();
+
+        return [
+            'id' => $this->id,
+            'name' => $this->{'name_'.$locale} ?? $this->name_en,
+            'description' => $this->{'description_'.$locale} ?? $this->description_en,
+            'price' => $this->price,
+            'stock' => $this->stock,
+            'image_url' => $this->image_path ? url($this->image_path) : null,
+            'created_at' => $this->created_at,
+        ];
+    }
+}

--- a/ve-shop-backend/app/Models/Product.php
+++ b/ve-shop-backend/app/Models/Product.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+
+class Product extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name_en',
+        'name_ar',
+        'description_en',
+        'description_ar',
+        'price',
+        'stock',
+        'image_path',
+    ];
+}

--- a/ve-shop-backend/bootstrap/app.php
+++ b/ve-shop-backend/bootstrap/app.php
@@ -7,11 +7,12 @@ use Illuminate\Foundation\Configuration\Middleware;
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
         web: __DIR__.'/../routes/web.php',
+        api: __DIR__.'/../routes/api.php',
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware): void {
-        //
+        $middleware->append(App\Http\Middleware\SetLocale::class);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         //

--- a/ve-shop-backend/database/migrations/0001_01_01_000004_create_products_table.php
+++ b/ve-shop-backend/database/migrations/0001_01_01_000004_create_products_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('products', function (Blueprint $table): void {
+            $table->id();
+            $table->string('name_en');
+            $table->string('name_ar');
+            $table->text('description_en')->nullable();
+            $table->text('description_ar')->nullable();
+            $table->decimal('price', 8, 2)->default(0);
+            $table->integer('stock')->default(0);
+            $table->string('image_path')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('products');
+    }
+};

--- a/ve-shop-backend/database/seeders/DatabaseSeeder.php
+++ b/ve-shop-backend/database/seeders/DatabaseSeeder.php
@@ -3,6 +3,7 @@
 namespace Database\Seeders;
 
 use App\Models\User;
+use Database\Seeders\ProductSeeder;
 // use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
@@ -14,7 +15,7 @@ class DatabaseSeeder extends Seeder
     public function run(): void
     {
         if (config('app.demo')) {
-            $this->call(DemoSeeder::class);
+            $this->call([DemoSeeder::class, ProductSeeder::class]);
             return;
         }
 
@@ -24,5 +25,7 @@ class DatabaseSeeder extends Seeder
             'name' => 'Test User',
             'email' => 'test@example.com',
         ]);
+
+        $this->call(ProductSeeder::class);
     }
 }

--- a/ve-shop-backend/database/seeders/ProductSeeder.php
+++ b/ve-shop-backend/database/seeders/ProductSeeder.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\Product;
+
+class ProductSeeder extends Seeder
+{
+    public function run(): void
+    {
+        Product::truncate();
+
+        Product::create([
+            'name_en' => 'Sample Product',
+            'name_ar' => 'منتج تجريبي',
+            'description_en' => 'Demo product description',
+            'description_ar' => 'وصف المنتج التجريبي',
+            'price' => 10.99,
+            'stock' => 50,
+        ]);
+    }
+}

--- a/ve-shop-backend/resources/lang/ar/messages.php
+++ b/ve-shop-backend/resources/lang/ar/messages.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+    'locale_switched' => 'تم تغيير اللغة بنجاح.',
+    'invalid_locale' => 'لغة غير صالحة.',
+    'deleted' => 'تم الحذف بنجاح.',
+];

--- a/ve-shop-backend/resources/lang/en/messages.php
+++ b/ve-shop-backend/resources/lang/en/messages.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+    'locale_switched' => 'Locale switched successfully.',
+    'invalid_locale' => 'Invalid locale.',
+    'deleted' => 'Deleted successfully.',
+];

--- a/ve-shop-backend/routes/api.php
+++ b/ve-shop-backend/routes/api.php
@@ -1,0 +1,11 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\Api\ProductController;
+use App\Http\Controllers\LocaleController;
+use App\Http\Middleware\SetLocale;
+
+Route::middleware([SetLocale::class])->group(function (): void {
+    Route::apiResource('products', ProductController::class);
+    Route::post('locale/{locale}', [LocaleController::class, 'switch']);
+});


### PR DESCRIPTION
## Summary
- implement basic API skeleton
- add Product resource, controller, request and model
- add localization middleware and locale switcher endpoint
- create migrations and seeders for products
- register API routes and middleware
- add minimal API setup instructions in README

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d097d64388330ac6dfd7ffff68bb6