### PR TITLE
Add responsive header with mobile support

### DIFF
--- a/ve-shop-frontend/src/components/layout/AccountDropdown.tsx
+++ b/ve-shop-frontend/src/components/layout/AccountDropdown.tsx
@@ -1,0 +1,93 @@
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Button } from "@/components/ui/button";
+import { LogOut, Package, Settings, User, UserCircle } from "lucide-react";
+import { useAuth } from "@/contexts/AuthContext";
+import { useNavigate } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+
+export const AccountDropdown = () => {
+  const { user, logout, isAuthenticated } = useAuth();
+  const navigate = useNavigate();
+  const { t } = useTranslation("common");
+
+  if (!isAuthenticated || !user) {
+    return (
+      <Button
+        variant="ghost"
+        onClick={() => navigate("/auth")}
+        className="flex items-center gap-2"
+        aria-label={t("actions.sign_in", "Sign In")}
+      >
+        <User className="w-5 h-5" />
+        <span className="hidden sm:inline">{t("actions.sign_in", "Sign In")}</span>
+      </Button>
+    );
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="relative h-9 w-9 rounded-full"
+          aria-label={t("navigation.account", "Account")}
+        >
+          <Avatar className="h-9 w-9">
+            <AvatarImage src={user.avatar} alt={`${user.firstName} ${user.lastName}`} />
+            <AvatarFallback>
+              {user.firstName[0]}
+              {user.lastName[0]}
+            </AvatarFallback>
+          </Avatar>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent className="w-56" align="end" forceMount>
+        <div className="flex items-center gap-2 p-2">
+          <div className="flex flex-col space-y-1 leading-none">
+            <p className="font-medium">
+              {user.firstName} {user.lastName}
+            </p>
+            <p className="w-[200px] truncate text-sm text-muted-foreground">
+              {user.email}
+            </p>
+          </div>
+        </div>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem onClick={() => navigate("/profile")}
+          className="cursor-pointer">
+          <UserCircle className="mr-2 h-4 w-4" />
+          <span>{t("navigation.profile", "Profile")}</span>
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => navigate("/profile?tab=orders")}
+          className="cursor-pointer">
+          <Package className="mr-2 h-4 w-4" />
+          <span>{t("navigation.orders", "Orders")}</span>
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => navigate("/profile?tab=settings")}
+          className="cursor-pointer">
+          <Settings className="mr-2 h-4 w-4" />
+          <span>{t("navigation.settings", "Settings")}</span>
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem
+          onClick={() => {
+            logout();
+            navigate("/");
+          }}
+          className="cursor-pointer text-destructive"
+        >
+          <LogOut className="mr-2 h-4 w-4" />
+          <span>{t("actions.logout", "Logout")}</span>
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+};

--- a/ve-shop-frontend/src/components/layout/Header.tsx
+++ b/ve-shop-frontend/src/components/layout/Header.tsx
@@ -1,23 +1,21 @@
-import { useState } from "react";
-import { Search, ShoppingCart, User, Menu, Heart, LogOut, UserCircle, Package, Settings } from "lucide-react";
+import { Search, ShoppingCart, Heart } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
-import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
 import { ThemeToggle } from "@/components/ui/theme-toggle";
 import { LanguageSwitcher } from "@/components/ui/language-switcher";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
-import { useAuth } from "@/contexts/AuthContext";
 import { useCartStore } from "@/store/cartStore";
 import { useWishlistStore } from "@/store/wishlistStore";
 import { NotificationCenter } from "@/components/notifications/NotificationCenter";
+import { AccountDropdown } from "./AccountDropdown";
+import { MobileMenu } from "./MobileMenu";
+import { MobileSearch } from "./MobileSearch";
 
 export const Header = () => {
   const { t } = useTranslation('common');
   const navigate = useNavigate();
-  const { user, logout, isAuthenticated } = useAuth();
   const cartCount = useCartStore((state) => state.getItemCount());
   const wishlistCount = useWishlistStore((state) => state.getItemCount());
 
@@ -59,12 +57,17 @@ export const Header = () => {
           {/* Actions */}
           <div className="flex items-center gap-2">
             {/* Wishlist */}
-            <Button variant="ghost" size="icon" className="relative">
+            <Button
+              variant="ghost"
+              size="icon"
+              className="relative"
+              aria-label="Wishlist"
+            >
               <Heart className="w-5 h-5" />
               {wishlistCount > 0 && (
-                <Badge 
-                  variant="secondary" 
-                  className="absolute -top-2 -right-2 h-5 w-5 flex items-center justify-center p-0 text-xs bg-secondary text-secondary-foreground"
+                <Badge
+                  variant="secondary"
+                  className="absolute -top-2 -right-2 h-5 w-5 flex items-center justify-center p-0 text-xs"
                 >
                   {wishlistCount}
                 </Badge>
@@ -75,17 +78,18 @@ export const Header = () => {
             <NotificationCenter />
 
             {/* Cart */}
-            <Button 
-              variant="ghost" 
-              size="icon" 
+            <Button
+              variant="ghost"
+              size="icon"
               className="relative"
               onClick={() => navigate('/checkout')}
+              aria-label="Cart"
             >
               <ShoppingCart className="w-5 h-5" />
               {cartCount > 0 && (
-                <Badge 
-                  variant="secondary" 
-                  className="absolute -top-2 -right-2 h-5 w-5 flex items-center justify-center p-0 text-xs bg-secondary text-secondary-foreground"
+                <Badge
+                  variant="secondary"
+                  className="absolute -top-2 -right-2 h-5 w-5 flex items-center justify-center p-0 text-xs"
                 >
                   {cartCount}
                 </Badge>
@@ -98,69 +102,13 @@ export const Header = () => {
             {/* Theme toggle */}
             <ThemeToggle />
 
-            {/* User account */}
-            {isAuthenticated && user ? (
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <Button variant="ghost" className="relative h-9 w-9 rounded-full">
-                    <Avatar className="h-9 w-9">
-                      <AvatarImage src={user.avatar} alt={`${user.firstName} ${user.lastName}`} />
-                      <AvatarFallback>
-                        {user.firstName[0]}{user.lastName[0]}
-                      </AvatarFallback>
-                    </Avatar>
-                  </Button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent className="w-56" align="end" forceMount>
-                  <div className="flex items-center justify-start gap-2 p-2">
-                    <div className="flex flex-col space-y-1 leading-none">
-                      <p className="font-medium">{user.firstName} {user.lastName}</p>
-                      <p className="w-[200px] truncate text-sm text-muted-foreground">
-                        {user.email}
-                      </p>
-                    </div>
-                  </div>
-                  <DropdownMenuSeparator />
-                  <DropdownMenuItem onClick={() => navigate('/profile')} className="cursor-pointer">
-                    <UserCircle className="mr-2 h-4 w-4" />
-                    <span>Profile</span>
-                  </DropdownMenuItem>
-                  <DropdownMenuItem onClick={() => navigate('/profile?tab=orders')} className="cursor-pointer">
-                    <Package className="mr-2 h-4 w-4" />
-                    <span>Orders</span>
-                  </DropdownMenuItem>
-                  <DropdownMenuItem onClick={() => navigate('/profile?tab=settings')} className="cursor-pointer">
-                    <Settings className="mr-2 h-4 w-4" />
-                    <span>Settings</span>
-                  </DropdownMenuItem>
-                  <DropdownMenuSeparator />
-                  <DropdownMenuItem 
-                    onClick={() => {
-                      logout();
-                      navigate('/');
-                    }}
-                    className="cursor-pointer text-destructive"
-                  >
-                    <LogOut className="mr-2 h-4 w-4" />
-                    <span>Logout</span>
-                  </DropdownMenuItem>
-                </DropdownMenuContent>
-              </DropdownMenu>
-            ) : (
-              <Button 
-                variant="ghost" 
-                onClick={() => navigate('/auth')}
-                className="flex items-center gap-2"
-              >
-                <User className="w-5 h-5" />
-                <span className="hidden sm:inline">Sign In</span>
-              </Button>
-            )}
+            {/* Account */}
+            <AccountDropdown />
 
+            {/* Mobile search */}
+            <MobileSearch />
             {/* Mobile menu */}
-            <Button variant="ghost" size="icon" className="md:hidden">
-              <Menu className="w-5 h-5" />
-            </Button>
+            <MobileMenu />
           </div>
         </div>
 

--- a/ve-shop-frontend/src/components/layout/MobileMenu.tsx
+++ b/ve-shop-frontend/src/components/layout/MobileMenu.tsx
@@ -1,0 +1,71 @@
+import { Heart, Menu, ShoppingCart } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
+import { Separator } from "@/components/ui/separator";
+import { ThemeToggle } from "@/components/ui/theme-toggle";
+import { LanguageSwitcher } from "@/components/ui/language-switcher";
+import { useCartStore } from "@/store/cartStore";
+import { useWishlistStore } from "@/store/wishlistStore";
+import { Badge } from "@/components/ui/badge";
+import { useNavigate } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+import { useLanguageStore } from "@/store/languageStore";
+import { AccountDropdown } from "./AccountDropdown";
+import { NotificationCenter } from "@/components/notifications/NotificationCenter";
+
+export const MobileMenu = () => {
+  const cartCount = useCartStore((s) => s.getItemCount());
+  const wishlistCount = useWishlistStore((s) => s.getItemCount());
+  const navigate = useNavigate();
+  const { t } = useTranslation("common");
+  const { direction } = useLanguageStore();
+
+  return (
+    <Sheet>
+      <SheetTrigger asChild>
+        <Button variant="ghost" size="icon" className="md:hidden" aria-label="Menu">
+          <Menu className="w-5 h-5" />
+        </Button>
+      </SheetTrigger>
+      <SheetContent
+        side={direction === "rtl" ? "right" : "left"}
+        className="flex flex-col gap-6 pt-10"
+      >
+        <nav className="flex flex-col gap-2">
+          <Button variant="ghost" className="justify-start" onClick={() => navigate("/")}>{t('categories.electronics')}</Button>
+          <Button variant="ghost" className="justify-start">{t('categories.fashion')}</Button>
+          <Button variant="ghost" className="justify-start">{t('categories.home')}</Button>
+          <Button variant="ghost" className="justify-start">{t('categories.sports')}</Button>
+          <Button variant="ghost" className="justify-start">{t('categories.books')}</Button>
+          <Button variant="ghost" className="justify-start">{t('categories.beauty')}</Button>
+          <Button variant="ghost" className="justify-start text-sale">🔥 {t('navigation.deals')}</Button>
+        </nav>
+        <Separator />
+        <div className="flex items-center gap-4">
+          <Button variant="ghost" size="icon" className="relative" onClick={() => navigate('/wishlist')} aria-label="Wishlist">
+            <Heart className="w-5 h-5" />
+            {wishlistCount > 0 && (
+              <Badge variant="secondary" className="absolute -top-2 -right-2 h-5 w-5 p-0 text-xs flex items-center justify-center">
+                {wishlistCount}
+              </Badge>
+            )}
+          </Button>
+          <Button variant="ghost" size="icon" className="relative" onClick={() => navigate('/checkout')} aria-label="Cart">
+            <ShoppingCart className="w-5 h-5" />
+            {cartCount > 0 && (
+              <Badge variant="secondary" className="absolute -top-2 -right-2 h-5 w-5 p-0 text-xs flex items-center justify-center">
+                {cartCount}
+              </Badge>
+            )}
+          </Button>
+          <NotificationCenter />
+        </div>
+        <AccountDropdown />
+        <div className="mt-auto flex items-center justify-between">
+          <LanguageSwitcher />
+          <ThemeToggle />
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+};

--- a/ve-shop-frontend/src/components/layout/MobileSearch.tsx
+++ b/ve-shop-frontend/src/components/layout/MobileSearch.tsx
@@ -1,0 +1,74 @@
+import { useState } from "react";
+import { Search } from "lucide-react";
+import {
+  CommandDialog,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import { Button } from "@/components/ui/button";
+import { useNavigate } from "react-router-dom";
+
+const products = [
+  { id: "1", name: "Wireless Bluetooth Headphones with Active Noise Cancellation" },
+  { id: "2", name: "Smart Fitness Watch with Heart Rate Monitor" },
+  { id: "3", name: "Professional Camera Lens 50mm f/1.8" },
+  { id: "4", name: "Ergonomic Office Chair with Lumbar Support" },
+  { id: "5", name: "Premium Coffee Machine with Milk Frother" },
+  { id: "6", name: "Mechanical Gaming Keyboard RGB Backlit" },
+  { id: "7", name: "Wireless Phone Charger Stand Fast Charging" },
+  { id: "8", name: "Smart Home Security Camera 1080p WiFi" },
+];
+
+export const MobileSearch = () => {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const navigate = useNavigate();
+
+  const filtered = query
+    ? products.filter((p) =>
+        p.name.toLowerCase().includes(query.toLowerCase())
+      )
+    : [];
+
+  const handleSelect = (id: string) => {
+    setOpen(false);
+    navigate(`/product/${id}`);
+  };
+
+  return (
+    <>
+      <Button
+        variant="ghost"
+        size="icon"
+        onClick={() => setOpen(true)}
+        className="md:hidden"
+        aria-label="Search"
+      >
+        <Search className="w-5 h-5" />
+      </Button>
+      <CommandDialog open={open} onOpenChange={setOpen}>
+        <CommandInput
+          value={query}
+          onValueChange={setQuery}
+          placeholder="Search products..."
+        />
+        <CommandList>
+          <CommandEmpty>No results found.</CommandEmpty>
+          <CommandGroup>
+            {filtered.map((product) => (
+              <CommandItem
+                key={product.id}
+                onSelect={() => handleSelect(product.id)}
+              >
+                {product.name}
+              </CommandItem>
+            ))}
+          </CommandGroup>
+        </CommandList>
+      </CommandDialog>
+    </>
+  );
+};


### PR DESCRIPTION
## Summary
- create `AccountDropdown` component for user actions
- add mobile menu via `Sheet` and include language/theme toggles
- implement mobile search modal with autocomplete
- refactor `Header` to use new components and improve accessibility

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686d0a926524833090b59caf51835f52