### PR TITLE
Add Category API

### DIFF
--- a/ve-shop-backend/README.md
+++ b/ve-shop-backend/README.md
@@ -69,3 +69,14 @@ php artisan demo:reset
 ```
 
 When demo mode is active you can quickly login as a demo user by posting to `/demo-login/{role}` where `{role}` is `admin`, `vendor`, or `customer`.
+
+## API Setup
+1. Copy `.env.example` to `.env` and configure your database.
+2. Run `php artisan migrate --seed` to create tables and demo data.
+3. Start the server with `php artisan serve`.
+
+### Sample requests
+```bash
+curl http://localhost:8000/api/products
+curl http://localhost:8000/api/categories
+```

--- a/ve-shop-backend/app/Http/Controllers/Api/CategoryController.php
+++ b/ve-shop-backend/app/Http/Controllers/Api/CategoryController.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\StoreCategoryRequest;
+use App\Http\Requests\UpdateCategoryRequest;
+use App\Http\Resources\CategoryResource;
+use App\Models\Category;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+
+class CategoryController extends Controller
+{
+    public function index(): AnonymousResourceCollection
+    {
+        $categories = Category::with('children')->paginate();
+        return CategoryResource::collection($categories);
+    }
+
+    public function store(StoreCategoryRequest $request): CategoryResource
+    {
+        $category = Category::create($request->validated());
+        return new CategoryResource($category);
+    }
+
+    public function show(Category $category): CategoryResource
+    {
+        return new CategoryResource($category->load('children'));
+    }
+
+    public function update(UpdateCategoryRequest $request, Category $category): CategoryResource
+    {
+        $category->update($request->validated());
+        return new CategoryResource($category);
+    }
+
+    public function destroy(Category $category): JsonResponse
+    {
+        $category->delete();
+        return response()->json(['message' => __('messages.deleted')]);
+    }
+}

--- a/ve-shop-backend/app/Http/Controllers/Api/ProductController.php
+++ b/ve-shop-backend/app/Http/Controllers/Api/ProductController.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\StoreProductRequest;
+use App\Http\Requests\UpdateProductRequest;
+use App\Http\Resources\ProductResource;
+use App\Models\Product;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+
+class ProductController extends Controller
+{
+    public function index(): AnonymousResourceCollection
+    {
+        $products = Product::paginate();
+        return ProductResource::collection($products);
+    }
+
+    public function store(StoreProductRequest $request): ProductResource
+    {
+        $data = $request->validated();
+        if ($request->hasFile('image')) {
+            $data['image_path'] = $request->file('image')->store('products', 'public');
+        }
+        $product = Product::create($data);
+        return new ProductResource($product);
+    }
+
+    public function show(Product $product): ProductResource
+    {
+        return new ProductResource($product);
+    }
+
+    public function update(UpdateProductRequest $request, Product $product): ProductResource
+    {
+        $data = $request->validated();
+        if ($request->hasFile('image')) {
+            $data['image_path'] = $request->file('image')->store('products', 'public');
+        }
+        $product->update($data);
+        return new ProductResource($product);
+    }
+
+    public function destroy(Product $product): JsonResponse
+    {
+        $product->delete();
+        return response()->json(['message' => __('messages.deleted')]);
+    }
+}

--- a/ve-shop-backend/app/Http/Controllers/LocaleController.php
+++ b/ve-shop-backend/app/Http/Controllers/LocaleController.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\App;
+
+class LocaleController extends Controller
+{
+    public function switch(string $locale): JsonResponse
+    {
+        if (! in_array($locale, ['en', 'ar'])) {
+            return response()->json(['message' => __('messages.invalid_locale')], 422);
+        }
+
+        App::setLocale($locale);
+
+        return response()->json([
+            'message' => __('messages.locale_switched'),
+            'locale' => $locale,
+        ]);
+    }
+}

--- a/ve-shop-backend/app/Http/Middleware/SetLocale.php
+++ b/ve-shop-backend/app/Http/Middleware/SetLocale.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\App;
+
+class SetLocale
+{
+    public function handle(Request $request, Closure $next)
+    {
+        $locale = $request->input('locale') ?? $request->header('Accept-Language');
+        if ($locale) {
+            $locale = substr($locale, 0, 2);
+            if (in_array($locale, ['en', 'ar'])) {
+                App::setLocale($locale);
+            }
+        }
+        return $next($request);
+    }
+}

--- a/ve-shop-backend/app/Http/Requests/StoreCategoryRequest.php
+++ b/ve-shop-backend/app/Http/Requests/StoreCategoryRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreCategoryRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'parent_id' => ['nullable', 'exists:categories,id'],
+            'slug' => ['required', 'string', 'max:255', 'unique:categories,slug'],
+            'name_en' => ['required', 'string', 'max:255'],
+            'name_ar' => ['required', 'string', 'max:255'],
+            'description_en' => ['nullable', 'string'],
+            'description_ar' => ['nullable', 'string'],
+        ];
+    }
+}

--- a/ve-shop-backend/app/Http/Requests/StoreProductRequest.php
+++ b/ve-shop-backend/app/Http/Requests/StoreProductRequest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreProductRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'name_en' => ['required', 'string', 'max:255'],
+            'name_ar' => ['required', 'string', 'max:255'],
+            'description_en' => ['nullable', 'string'],
+            'description_ar' => ['nullable', 'string'],
+            'price' => ['required', 'numeric', 'min:0'],
+            'stock' => ['required', 'integer', 'min:0'],
+            'image' => ['nullable', 'image'],
+        ];
+    }
+}

--- a/ve-shop-backend/app/Http/Requests/UpdateCategoryRequest.php
+++ b/ve-shop-backend/app/Http/Requests/UpdateCategoryRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateCategoryRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'parent_id' => ['nullable', 'exists:categories,id'],
+            'slug' => ['sometimes', 'string', 'max:255', 'unique:categories,slug,'.$this->category?->id],
+            'name_en' => ['sometimes', 'string', 'max:255'],
+            'name_ar' => ['sometimes', 'string', 'max:255'],
+            'description_en' => ['nullable', 'string'],
+            'description_ar' => ['nullable', 'string'],
+        ];
+    }
+}

--- a/ve-shop-backend/app/Http/Requests/UpdateProductRequest.php
+++ b/ve-shop-backend/app/Http/Requests/UpdateProductRequest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateProductRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'name_en' => ['sometimes', 'string', 'max:255'],
+            'name_ar' => ['sometimes', 'string', 'max:255'],
+            'description_en' => ['nullable', 'string'],
+            'description_ar' => ['nullable', 'string'],
+            'price' => ['sometimes', 'numeric', 'min:0'],
+            'stock' => ['sometimes', 'integer', 'min:0'],
+            'image' => ['nullable', 'image'],
+        ];
+    }
+}

--- a/ve-shop-backend/app/Http/Resources/CategoryResource.php
+++ b/ve-shop-backend/app/Http/Resources/CategoryResource.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class CategoryResource extends JsonResource
+{
+    public function toArray($request): array
+    {
+        $locale = app()->getLocale();
+
+        return [
+            'id' => $this->id,
+            'slug' => $this->slug,
+            'name' => $this->{'name_'.$locale} ?? $this->name_en,
+            'description' => $this->{'description_'.$locale} ?? $this->description_en,
+            'parent_id' => $this->parent_id,
+            'created_at' => $this->created_at,
+        ];
+    }
+}

--- a/ve-shop-backend/app/Http/Resources/ProductResource.php
+++ b/ve-shop-backend/app/Http/Resources/ProductResource.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class ProductResource extends JsonResource
+{
+    public function toArray($request): array
+    {
+        $locale = app()->getLocale();
+
+        return [
+            'id' => $this->id,
+            'name' => $this->{'name_'.$locale} ?? $this->name_en,
+            'description' => $this->{'description_'.$locale} ?? $this->description_en,
+            'price' => $this->price,
+            'stock' => $this->stock,
+            'image_url' => $this->image_path ? url($this->image_path) : null,
+            'created_at' => $this->created_at,
+        ];
+    }
+}

--- a/ve-shop-backend/app/Models/Category.php
+++ b/ve-shop-backend/app/Models/Category.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Category extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'parent_id',
+        'slug',
+        'name_en',
+        'name_ar',
+        'description_en',
+        'description_ar',
+    ];
+
+    public function parent()
+    {
+        return $this->belongsTo(self::class, 'parent_id');
+    }
+
+    public function children()
+    {
+        return $this->hasMany(self::class, 'parent_id');
+    }
+}

--- a/ve-shop-backend/app/Models/Product.php
+++ b/ve-shop-backend/app/Models/Product.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+
+class Product extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name_en',
+        'name_ar',
+        'description_en',
+        'description_ar',
+        'price',
+        'stock',
+        'image_path',
+    ];
+}

--- a/ve-shop-backend/bootstrap/app.php
+++ b/ve-shop-backend/bootstrap/app.php
@@ -7,11 +7,12 @@ use Illuminate\Foundation\Configuration\Middleware;
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
         web: __DIR__.'/../routes/web.php',
+        api: __DIR__.'/../routes/api.php',
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware): void {
-        //
+        $middleware->append(App\Http\Middleware\SetLocale::class);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         //

--- a/ve-shop-backend/database/migrations/0001_01_01_000004_create_products_table.php
+++ b/ve-shop-backend/database/migrations/0001_01_01_000004_create_products_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('products', function (Blueprint $table): void {
+            $table->id();
+            $table->string('name_en');
+            $table->string('name_ar');
+            $table->text('description_en')->nullable();
+            $table->text('description_ar')->nullable();
+            $table->decimal('price', 8, 2)->default(0);
+            $table->integer('stock')->default(0);
+            $table->string('image_path')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('products');
+    }
+};

--- a/ve-shop-backend/database/migrations/0001_01_01_000005_create_categories_table.php
+++ b/ve-shop-backend/database/migrations/0001_01_01_000005_create_categories_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('categories', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('parent_id')->nullable()->constrained('categories')->nullOnDelete();
+            $table->string('slug')->unique();
+            $table->string('name_en');
+            $table->string('name_ar');
+            $table->text('description_en')->nullable();
+            $table->text('description_ar')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('categories');
+    }
+};

--- a/ve-shop-backend/database/seeders/CategorySeeder.php
+++ b/ve-shop-backend/database/seeders/CategorySeeder.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\Category;
+use Illuminate\Support\Str;
+
+class CategorySeeder extends Seeder
+{
+    public function run(): void
+    {
+        Category::truncate();
+
+        $root = Category::create([
+            'slug' => Str::slug('Electronics'),
+            'name_en' => 'Electronics',
+            'name_ar' => 'إلكترونيات',
+            'description_en' => 'Electronic devices',
+            'description_ar' => 'أجهزة إلكترونية',
+        ]);
+
+        Category::create([
+            'parent_id' => $root->id,
+            'slug' => Str::slug('Mobile Phones'),
+            'name_en' => 'Mobile Phones',
+            'name_ar' => 'هواتف محمولة',
+            'description_en' => 'Smartphones and accessories',
+            'description_ar' => 'هواتف ذكية واكسسوارات',
+        ]);
+    }
+}

--- a/ve-shop-backend/database/seeders/DatabaseSeeder.php
+++ b/ve-shop-backend/database/seeders/DatabaseSeeder.php
@@ -3,6 +3,8 @@
 namespace Database\Seeders;
 
 use App\Models\User;
+use Database\Seeders\ProductSeeder;
+use Database\Seeders\CategorySeeder;
 // use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
@@ -14,7 +16,11 @@ class DatabaseSeeder extends Seeder
     public function run(): void
     {
         if (config('app.demo')) {
-            $this->call(DemoSeeder::class);
+            $this->call([
+                DemoSeeder::class,
+                ProductSeeder::class,
+                CategorySeeder::class,
+            ]);
             return;
         }
 
@@ -23,6 +29,11 @@ class DatabaseSeeder extends Seeder
         User::factory()->create([
             'name' => 'Test User',
             'email' => 'test@example.com',
+        ]);
+
+        $this->call([
+            CategorySeeder::class,
+            ProductSeeder::class,
         ]);
     }
 }

--- a/ve-shop-backend/database/seeders/ProductSeeder.php
+++ b/ve-shop-backend/database/seeders/ProductSeeder.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\Product;
+
+class ProductSeeder extends Seeder
+{
+    public function run(): void
+    {
+        Product::truncate();
+
+        Product::create([
+            'name_en' => 'Sample Product',
+            'name_ar' => 'منتج تجريبي',
+            'description_en' => 'Demo product description',
+            'description_ar' => 'وصف المنتج التجريبي',
+            'price' => 10.99,
+            'stock' => 50,
+        ]);
+    }
+}

--- a/ve-shop-backend/resources/lang/ar/messages.php
+++ b/ve-shop-backend/resources/lang/ar/messages.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+    'locale_switched' => 'تم تغيير اللغة بنجاح.',
+    'invalid_locale' => 'لغة غير صالحة.',
+    'deleted' => 'تم الحذف بنجاح.',
+];

--- a/ve-shop-backend/resources/lang/en/messages.php
+++ b/ve-shop-backend/resources/lang/en/messages.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+    'locale_switched' => 'Locale switched successfully.',
+    'invalid_locale' => 'Invalid locale.',
+    'deleted' => 'Deleted successfully.',
+];

--- a/ve-shop-backend/routes/api.php
+++ b/ve-shop-backend/routes/api.php
@@ -1,0 +1,13 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\Api\ProductController;
+use App\Http\Controllers\Api\CategoryController;
+use App\Http\Controllers\LocaleController;
+use App\Http\Middleware\SetLocale;
+
+Route::middleware([SetLocale::class])->group(function (): void {
+    Route::apiResource('products', ProductController::class);
+    Route::apiResource('categories', CategoryController::class);
+    Route::post('locale/{locale}', [LocaleController::class, 'switch']);
+});


### PR DESCRIPTION
## Summary
- add migration and seeder for categories
- implement Category model, resource, requests and controller
- register categories endpoint and update demo data
- fix README API section formatting with example category request

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d097d64388330ac6dfd7ffff68bb6