### PR TITLE
Fix header logo order for RTL

### DIFF
--- a/ve-shop-frontend/src/components/layout/Header.tsx
+++ b/ve-shop-frontend/src/components/layout/Header.tsx
@@ -24,10 +24,8 @@ export const Header = () => {
   const { direction } = useLanguageStore();
   const isRTL = direction === "rtl";
 
-  // ترتيب المناطق (zones) حسب اللغة
-  const zones = isRTL
-    ? ['actions', 'search', 'logo']
-    : ['logo', 'search', 'actions'];
+  // نفس ترتيب المناطق (zones) في جميع اللغات
+  const zones = ['logo', 'search', 'actions'];
 
   return (
     <header


### PR DESCRIPTION
## Summary
- ensure the logo appears before the search field in RTL

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686d4c965fa48330af1f6af29cdd9e57