### PR TITLE
Fix RTL menu sliding and checkout direction

### DIFF
--- a/ve-shop-frontend/src/components/checkout/CheckoutSteps.tsx
+++ b/ve-shop-frontend/src/components/checkout/CheckoutSteps.tsx
@@ -1,5 +1,6 @@
 import { Check } from "lucide-react";
 import { useTranslation } from "react-i18next";
+import { useLanguageStore } from "@/store/languageStore";
 
 interface CheckoutStepsProps {
   currentStep: number;
@@ -7,6 +8,8 @@ interface CheckoutStepsProps {
 
 export const CheckoutSteps = ({ currentStep }: CheckoutStepsProps) => {
   const { t } = useTranslation('cart');
+  const { direction } = useLanguageStore();
+  const isRTL = direction === 'rtl';
   
   const steps = [
     { key: 1, label: t('checkout.cart_review', 'Cart Review') },
@@ -16,7 +19,10 @@ export const CheckoutSteps = ({ currentStep }: CheckoutStepsProps) => {
   ];
 
   return (
-    <div className="flex items-center justify-between mb-8">
+    <div
+      dir={direction}
+      className={`flex items-center justify-between mb-8 ${isRTL ? 'flex-row-reverse' : ''}`}
+    >
       {steps.map((step, index) => (
         <div key={step.key} className="flex items-center flex-1">
           {/* Step Circle */}

--- a/ve-shop-frontend/src/components/layout/MobileMenu.tsx
+++ b/ve-shop-frontend/src/components/layout/MobileMenu.tsx
@@ -32,8 +32,12 @@ export const MobileMenu = () => {
           <Menu className="w-5 h-5" />
         </Button>
       </SheetTrigger>
+      {/*
+        Mobile drawer direction adjusts based on the current language.
+        Arabic (rtl) should slide from the right, English from the left.
+      */}
       <SheetContent
-        side={direction === "rtl" ? "left" : "right"}
+        side={direction === "rtl" ? "right" : "left"}
         className="flex flex-col gap-6 pt-10"
       >
         <nav className="flex flex-col gap-2">

--- a/ve-shop-frontend/src/pages/Checkout.tsx
+++ b/ve-shop-frontend/src/pages/Checkout.tsx
@@ -10,12 +10,14 @@ import { CheckoutSteps } from "@/components/checkout/CheckoutSteps";
 import { useOrderStore } from "@/stores/orderStore";
 import { useCartStore } from "@/store/cartStore";
 import { useTranslation } from "react-i18next";
+import { useLanguageStore } from "@/store/languageStore";
 
 const Checkout = () => {
   const { t } = useTranslation('cart');
   const navigate = useNavigate();
   const { currentCheckoutStep, setCheckoutStep, clearCheckout } = useOrderStore();
   const { items, getItemCount } = useCartStore();
+  const { direction } = useLanguageStore();
 
   // Redirect if cart is empty (except on confirmation step)
   useEffect(() => {
@@ -49,7 +51,7 @@ const Checkout = () => {
   };
 
   return (
-    <div className="min-h-screen bg-background">
+    <div className="min-h-screen bg-background" dir={direction}>
       <Header />
       
       <main className="py-8">
@@ -71,5 +73,4 @@ const Checkout = () => {
     </div>
   );
 };
-
 export default Checkout;


### PR DESCRIPTION
## Summary
- adjust mobile menu drawer to open from language-specific side
- make checkout step component direction-aware
- set checkout page dir attribute for RTL/LTR

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686df170d8288330bc33f6454a8306db