### PR TITLE
Improve RTL checkout direction support

### DIFF
--- a/ve-shop-frontend/src/components/checkout/CartReview.tsx
+++ b/ve-shop-frontend/src/components/checkout/CartReview.tsx
@@ -8,16 +8,18 @@ import { useOrderStore } from "@/stores/orderStore";
 import { useNotificationStore } from "@/stores/notificationStore";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
+import { useLanguageStore } from "@/store/languageStore";
 
 export const CartReview = () => {
-  const { t } = useTranslation(['cart', 'ui']);
-  const [couponCode, setCouponCode] = useState('');
+  const { t } = useTranslation(["cart", "ui"]);
+  const [couponCode, setCouponCode] = useState("");
   const [appliedCoupon, setAppliedCoupon] = useState<string | null>(null);
   const [discount, setDiscount] = useState(0);
-  
+
   const { items, updateQuantity, removeItem, getSubtotal } = useCartStore();
   const { setCheckoutStep, setCouponCode: setOrderCoupon } = useOrderStore();
   const { addNotification } = useNotificationStore();
+  const { direction } = useLanguageStore();
 
   const subtotal = getSubtotal();
   const tax = subtotal * 0.1; // 10% tax
@@ -31,41 +33,46 @@ export const CartReview = () => {
 
   const handleRemoveItem = (id: string, name: string) => {
     removeItem(id);
-    toast.success(t('ui:toast.item_removed_from_cart'));
+    toast.success(t("ui:toast.item_removed_from_cart"));
     addNotification({
-      type: 'info',
-      title: t('ui:toast.item_removed_from_cart'),
-      message: `${name} ${t('cart:cart.remove_item')}`,
-      category: 'order'
+      type: "info",
+      title: t("ui:toast.item_removed_from_cart"),
+      message: `${name} ${t("cart:cart.remove_item")}`,
+      category: "order",
     });
   };
 
   const handleApplyCoupon = () => {
     if (!couponCode.trim()) return;
-    
+
     // Mock coupon validation
     const mockCoupons: Record<string, number> = {
-      'SAVE10': 10,
-      'WELCOME20': 20,
-      'STUDENT15': 15
+      SAVE10: 10,
+      WELCOME20: 20,
+      STUDENT15: 15,
     };
-    
+
     const couponDiscount = mockCoupons[couponCode.toUpperCase()];
-    
+
     if (couponDiscount) {
       const discountAmount = (subtotal * couponDiscount) / 100;
       setDiscount(discountAmount);
       setAppliedCoupon(couponCode.toUpperCase());
       setOrderCoupon(couponCode.toUpperCase(), discountAmount);
-      toast.success(t('cart:cart.coupon_applied', `Coupon applied! ${couponDiscount}% discount`));
+      toast.success(
+        t(
+          "cart:cart.coupon_applied",
+          `Coupon applied! ${couponDiscount}% discount`,
+        ),
+      );
     } else {
-      toast.error(t('cart:cart.invalid_coupon', 'Invalid coupon code'));
+      toast.error(t("cart:cart.invalid_coupon", "Invalid coupon code"));
     }
   };
 
   const handleProceedToShipping = () => {
     if (items.length === 0) {
-      toast.error(t('cart:cart.empty_cart'));
+      toast.error(t("cart:cart.empty_cart"));
       return;
     }
     setCheckoutStep(2);
@@ -75,17 +82,17 @@ export const CartReview = () => {
     return (
       <div className="text-center py-12">
         <h2 className="text-2xl font-semibold text-muted-foreground mb-4">
-          {t('cart:cart.empty_cart')}
+          {t("cart:cart.empty_cart")}
         </h2>
         <Button onClick={() => window.history.back()}>
-          {t('cart:cart.continue_shopping')}
+          {t("cart:cart.continue_shopping")}
         </Button>
       </div>
     );
   }
 
   return (
-    <div className="space-y-6">
+    <div dir={direction} className="space-y-6">
       <div className="space-y-4">
         {items.map((item) => (
           <Card key={item.id}>
@@ -96,12 +103,20 @@ export const CartReview = () => {
                   alt={item.name}
                   className="w-16 h-16 object-cover rounded-md"
                 />
-                
+
                 <div className="flex-1">
                   <h3 className="font-medium text-foreground">{item.name}</h3>
                   <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                    {item.color && <span>{t('cart:product.color', 'Color')}: {item.color}</span>}
-                    {item.size && <span>{t('cart:product.size', 'Size')}: {item.size}</span>}
+                    {item.color && (
+                      <span>
+                        {t("cart:product.color", "Color")}: {item.color}
+                      </span>
+                    )}
+                    {item.size && (
+                      <span>
+                        {t("cart:product.size", "Size")}: {item.size}
+                      </span>
+                    )}
                   </div>
                   <div className="flex items-center gap-2 mt-2">
                     <span className="font-semibold text-primary">
@@ -114,28 +129,34 @@ export const CartReview = () => {
                     )}
                   </div>
                 </div>
-                
+
                 <div className="flex items-center gap-2">
                   <Button
                     variant="outline"
                     size="icon"
-                    onClick={() => handleQuantityChange(item.id, item.quantity - 1)}
+                    onClick={() =>
+                      handleQuantityChange(item.id, item.quantity - 1)
+                    }
                     disabled={item.quantity <= 1}
                   >
                     <Minus className="w-4 h-4" />
                   </Button>
-                  
-                  <span className="w-8 text-center font-medium">{item.quantity}</span>
-                  
+
+                  <span className="w-8 text-center font-medium">
+                    {item.quantity}
+                  </span>
+
                   <Button
                     variant="outline"
                     size="icon"
-                    onClick={() => handleQuantityChange(item.id, item.quantity + 1)}
+                    onClick={() =>
+                      handleQuantityChange(item.id, item.quantity + 1)
+                    }
                   >
                     <Plus className="w-4 h-4" />
                   </Button>
                 </div>
-                
+
                 <div className="text-right">
                   <div className="font-semibold">
                     ${(item.price * item.quantity).toFixed(2)}
@@ -147,7 +168,7 @@ export const CartReview = () => {
                     className="text-destructive hover:text-destructive"
                   >
                     <Trash2 className="w-4 h-4 mr-1" />
-                    {t('cart:cart.remove_item')}
+                    {t("cart:cart.remove_item")}
                   </Button>
                 </div>
               </div>
@@ -162,7 +183,7 @@ export const CartReview = () => {
           <CardHeader>
             <CardTitle className="flex items-center gap-2">
               <Tag className="w-5 h-5" />
-              {t('cart:cart.coupon_code')}
+              {t("cart:cart.coupon_code")}
             </CardTitle>
           </CardHeader>
           <CardContent className="space-y-3">
@@ -178,26 +199,29 @@ export const CartReview = () => {
                     onClick={() => {
                       setAppliedCoupon(null);
                       setDiscount(0);
-                      setCouponCode('');
+                      setCouponCode("");
                     }}
                     className="text-xs"
                   >
-                    {t('cart:cart.remove', 'Remove')}
+                    {t("cart:cart.remove", "Remove")}
                   </Button>
                 </div>
                 <p className="text-xs text-green-600 dark:text-green-400">
-                  ${discount.toFixed(2)} {t('cart:cart.discount')}
+                  ${discount.toFixed(2)} {t("cart:cart.discount")}
                 </p>
               </div>
             ) : (
               <>
                 <Input
-                  placeholder={t('cart:cart.enter_coupon_code', 'Enter coupon code')}
+                  placeholder={t(
+                    "cart:cart.enter_coupon_code",
+                    "Enter coupon code",
+                  )}
                   value={couponCode}
                   onChange={(e) => setCouponCode(e.target.value)}
                 />
                 <Button onClick={handleApplyCoupon} className="w-full">
-                  {t('cart:cart.apply_coupon')}
+                  {t("cart:cart.apply_coupon")}
                 </Button>
               </>
             )}
@@ -207,44 +231,47 @@ export const CartReview = () => {
         {/* Order Summary */}
         <Card className="lg:col-span-2">
           <CardHeader>
-            <CardTitle>{t('cart:checkout.order_summary')}</CardTitle>
+            <CardTitle>{t("cart:checkout.order_summary")}</CardTitle>
           </CardHeader>
           <CardContent className="space-y-3">
             <div className="flex justify-between">
-              <span>{t('cart:cart.subtotal')}</span>
+              <span>{t("cart:cart.subtotal")}</span>
               <span>${subtotal.toFixed(2)}</span>
             </div>
-            
+
             <div className="flex justify-between">
-              <span>{t('cart:cart.shipping')}</span>
-              <span>{shipping === 0 ? t('cart:cart.free', 'Free') : `$${shipping.toFixed(2)}`}</span>
+              <span>{t("cart:cart.shipping")}</span>
+              <span>
+                {shipping === 0
+                  ? t("cart:cart.free", "Free")
+                  : `$${shipping.toFixed(2)}`}
+              </span>
             </div>
-            
+
             <div className="flex justify-between">
-              <span>{t('cart:cart.tax')}</span>
+              <span>{t("cart:cart.tax")}</span>
               <span>${tax.toFixed(2)}</span>
             </div>
-            
+
             {discount > 0 && (
               <div className="flex justify-between text-green-600 dark:text-green-400">
-                <span>{t('cart:cart.discount')}</span>
+                <span>{t("cart:cart.discount")}</span>
                 <span>-${discount.toFixed(2)}</span>
               </div>
             )}
-            
+
             <div className="border-t pt-3">
               <div className="flex justify-between text-lg font-semibold">
-                <span>{t('cart:cart.total')}</span>
+                <span>{t("cart:cart.total")}</span>
                 <span>${total.toFixed(2)}</span>
               </div>
             </div>
-            
+
             <Button onClick={handleProceedToShipping} className="w-full mt-4">
-              {t('cart:checkout.proceed_to_shipping', 'Proceed to Shipping')}
+              {t("cart:checkout.proceed_to_shipping", "Proceed to Shipping")}
             </Button>
           </CardContent>
         </Card>
       </div>
     </div>
-  );
-};
+  );};

--- a/ve-shop-frontend/src/components/checkout/CheckoutSteps.tsx
+++ b/ve-shop-frontend/src/components/checkout/CheckoutSteps.tsx
@@ -7,21 +7,21 @@ interface CheckoutStepsProps {
 }
 
 export const CheckoutSteps = ({ currentStep }: CheckoutStepsProps) => {
-  const { t } = useTranslation('cart');
+  const { t } = useTranslation("cart");
   const { direction } = useLanguageStore();
-  const isRTL = direction === 'rtl';
-  
+  const isRTL = direction === "rtl";
+
   const steps = [
-    { key: 1, label: t('checkout.cart_review', 'Cart Review') },
-    { key: 2, label: t('checkout.shipping_address') },
-    { key: 3, label: t('checkout.payment_method') },
-    { key: 4, label: t('checkout.confirmation', 'Confirmation') }
+    { key: 1, label: t("checkout.cart_review", "Cart Review") },
+    { key: 2, label: t("checkout.shipping_address") },
+    { key: 3, label: t("checkout.payment_method") },
+    { key: 4, label: t("checkout.confirmation", "Confirmation") },
   ];
 
   return (
     <div
       dir={direction}
-      className={`flex items-center justify-between mb-8 ${isRTL ? 'flex-row-reverse' : ''}`}
+      className={`flex items-center justify-between mb-8 ${isRTL ? "flex-row-reverse" : ""}`}
     >
       {steps.map((step, index) => (
         <div key={step.key} className="flex items-center flex-1">
@@ -30,10 +30,10 @@ export const CheckoutSteps = ({ currentStep }: CheckoutStepsProps) => {
             <div
               className={`w-8 h-8 rounded-full flex items-center justify-center text-sm font-medium transition-colors ${
                 step.key < currentStep
-                  ? 'bg-primary text-primary-foreground'
+                  ? "bg-primary text-primary-foreground"
                   : step.key === currentStep
-                  ? 'bg-primary text-primary-foreground'
-                  : 'bg-muted text-muted-foreground'
+                    ? "bg-primary text-primary-foreground"
+                    : "bg-muted text-muted-foreground"
               }`}
             >
               {step.key < currentStep ? (
@@ -42,31 +42,28 @@ export const CheckoutSteps = ({ currentStep }: CheckoutStepsProps) => {
                 step.key
               )}
             </div>
-            
+
             {/* Step Label */}
             <span
-              className={`ml-2 text-sm font-medium transition-colors ${
+              className={`${isRTL ? "mr-2" : "ml-2"} text-sm font-medium transition-colors ${
                 step.key <= currentStep
-                  ? 'text-foreground'
-                  : 'text-muted-foreground'
+                  ? "text-foreground"
+                  : "text-muted-foreground"
               }`}
             >
               {step.label}
             </span>
           </div>
-          
+
           {/* Connector Line */}
           {index < steps.length - 1 && (
             <div
               className={`flex-1 h-0.5 mx-4 transition-colors ${
-                step.key < currentStep
-                  ? 'bg-primary'
-                  : 'bg-muted'
+                step.key < currentStep ? "bg-primary" : "bg-muted"
               }`}
             />
           )}
         </div>
       ))}
     </div>
-  );
-};
+  );};

--- a/ve-shop-frontend/src/components/checkout/OrderConfirmation.tsx
+++ b/ve-shop-frontend/src/components/checkout/OrderConfirmation.tsx
@@ -5,12 +5,14 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { useOrderStore } from "@/stores/orderStore";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
+import { useLanguageStore } from "@/store/languageStore";
 
 export const OrderConfirmation = () => {
-  const { t } = useTranslation('cart');
+  const { t } = useTranslation("cart");
   const navigate = useNavigate();
   const { orders, clearCheckout } = useOrderStore();
   const [currentOrder, setCurrentOrder] = useState(orders[0]);
+  const { direction } = useLanguageStore();
 
   useEffect(() => {
     // Get the most recent order
@@ -21,7 +23,7 @@ export const OrderConfirmation = () => {
 
   const handleContinueShopping = () => {
     clearCheckout();
-    navigate('/');
+    navigate("/");
   };
 
   const handleViewOrder = () => {
@@ -32,28 +34,26 @@ export const OrderConfirmation = () => {
     return (
       <div className="text-center py-12">
         <h2 className="text-2xl font-semibold text-muted-foreground mb-4">
-          {t('order.no_order_found', 'No order found')}
+          {t("order.no_order_found", "No order found")}
         </h2>
         <Button onClick={handleContinueShopping}>
-          {t('cart.continue_shopping')}
+          {t("cart.continue_shopping")}
         </Button>
       </div>
     );
   }
 
   return (
-    <div className="space-y-6">
+    <div dir={direction} className="space-y-6">
       {/* Success Header */}
       <div className="text-center py-8">
         <div className="w-16 h-16 bg-green-100 dark:bg-green-900/20 rounded-full flex items-center justify-center mx-auto mb-4">
           <CheckCircle className="w-8 h-8 text-green-600" />
         </div>
         <h1 className="text-3xl font-bold text-foreground mb-2">
-          {t('order.order_confirmed')}
+          {t("order.order_confirmed")}
         </h1>
-        <p className="text-lg text-muted-foreground">
-          {t('order.thank_you')}
-        </p>
+        <p className="text-lg text-muted-foreground">{t("order.thank_you")}</p>
       </div>
 
       {/* Order Details */}
@@ -62,34 +62,44 @@ export const OrderConfirmation = () => {
           <CardHeader>
             <CardTitle className="flex items-center gap-2">
               <Package className="w-5 h-5" />
-              {t('order.order_details')}
+              {t("order.order_details")}
             </CardTitle>
           </CardHeader>
           <CardContent className="space-y-4">
             <div className="flex justify-between">
-              <span className="font-medium">{t('order.order_number')}</span>
-              <span className="text-primary font-mono">{currentOrder.orderNumber}</span>
+              <span className="font-medium">{t("order.order_number")}</span>
+              <span className="text-primary font-mono">
+                {currentOrder.orderNumber}
+              </span>
             </div>
-            
+
             <div className="flex justify-between">
-              <span>{t('order.order_date', 'Order Date')}</span>
-              <span>{new Date(currentOrder.createdAt).toLocaleDateString()}</span>
+              <span>{t("order.order_date", "Order Date")}</span>
+              <span>
+                {new Date(currentOrder.createdAt).toLocaleDateString()}
+              </span>
             </div>
-            
+
             <div className="flex justify-between">
-              <span>{t('order.order_status')}</span>
+              <span>{t("order.order_status")}</span>
               <span className="capitalize bg-blue-100 dark:bg-blue-900/20 text-blue-700 dark:text-blue-300 px-2 py-1 rounded-md text-sm">
                 {t(`order.${currentOrder.status}`, currentOrder.status)}
               </span>
             </div>
-            
+
             <div className="flex justify-between">
-              <span>{t('order.estimated_delivery')}</span>
-              <span>{currentOrder.estimatedDelivery ? new Date(currentOrder.estimatedDelivery).toLocaleDateString() : t('order.calculating', 'Calculating...')}</span>
+              <span>{t("order.estimated_delivery")}</span>
+              <span>
+                {currentOrder.estimatedDelivery
+                  ? new Date(
+                      currentOrder.estimatedDelivery,
+                    ).toLocaleDateString()
+                  : t("order.calculating", "Calculating...")}
+              </span>
             </div>
-            
+
             <div className="flex justify-between font-semibold text-lg pt-2 border-t">
-              <span>{t('cart.total')}</span>
+              <span>{t("cart.total")}</span>
               <span>${currentOrder.total.toFixed(2)}</span>
             </div>
           </CardContent>
@@ -98,16 +108,23 @@ export const OrderConfirmation = () => {
         {/* Shipping Information */}
         <Card>
           <CardHeader>
-            <CardTitle>{t('checkout.shipping_address')}</CardTitle>
+            <CardTitle>{t("checkout.shipping_address")}</CardTitle>
           </CardHeader>
           <CardContent>
             <div className="space-y-2 text-sm">
               <p className="font-medium">{currentOrder.shippingAddress.name}</p>
               <p>{currentOrder.shippingAddress.street}</p>
-              <p>{currentOrder.shippingAddress.city}, {currentOrder.shippingAddress.state} {currentOrder.shippingAddress.zipCode}</p>
+              <p>
+                {currentOrder.shippingAddress.city},{" "}
+                {currentOrder.shippingAddress.state}{" "}
+                {currentOrder.shippingAddress.zipCode}
+              </p>
               <p>{currentOrder.shippingAddress.country}</p>
               {currentOrder.shippingAddress.phone && (
-                <p>{t('address.phone', 'Phone')}: {currentOrder.shippingAddress.phone}</p>
+                <p>
+                  {t("address.phone", "Phone")}:{" "}
+                  {currentOrder.shippingAddress.phone}
+                </p>
               )}
             </div>
           </CardContent>
@@ -117,12 +134,15 @@ export const OrderConfirmation = () => {
       {/* Order Items */}
       <Card>
         <CardHeader>
-          <CardTitle>{t('order.items_ordered', 'Items Ordered')}</CardTitle>
+          <CardTitle>{t("order.items_ordered", "Items Ordered")}</CardTitle>
         </CardHeader>
         <CardContent>
           <div className="space-y-4">
             {currentOrder.items.map((item) => (
-              <div key={item.id} className="flex items-center gap-4 p-3 border rounded-lg">
+              <div
+                key={item.id}
+                className="flex items-center gap-4 p-3 border rounded-lg"
+              >
                 <img
                   src={item.image}
                   alt={item.name}
@@ -131,14 +151,22 @@ export const OrderConfirmation = () => {
                 <div className="flex-1">
                   <h4 className="font-medium">{item.name}</h4>
                   <div className="text-sm text-muted-foreground">
-                    {item.color && <span>{t('product.color', 'Color')}: {item.color} </span>}
-                    {item.size && <span>{t('product.size', 'Size')}: {item.size}</span>}
+                    {item.color && (
+                      <span>
+                        {t("product.color", "Color")}: {item.color}{" "}
+                      </span>
+                    )}
+                    {item.size && (
+                      <span>
+                        {t("product.size", "Size")}: {item.size}
+                      </span>
+                    )}
                   </div>
                 </div>
                 <div className="text-right">
                   <div className="font-medium">${item.price.toFixed(2)}</div>
                   <div className="text-sm text-muted-foreground">
-                    {t('product.qty', 'Qty')}: {item.quantity}
+                    {t("product.qty", "Qty")}: {item.quantity}
                   </div>
                 </div>
               </div>
@@ -149,12 +177,16 @@ export const OrderConfirmation = () => {
 
       {/* Action Buttons */}
       <div className="flex flex-col sm:flex-row gap-4 pt-6">
-        <Button onClick={handleContinueShopping} variant="outline" className="flex-1">
-          {t('cart.continue_shopping')}
+        <Button
+          onClick={handleContinueShopping}
+          variant="outline"
+          className="flex-1"
+        >
+          {t("cart.continue_shopping")}
         </Button>
-        
+
         <Button onClick={handleViewOrder} className="flex-1">
-          {t('order.view_order_details', 'View Order Details')}
+          {t("order.view_order_details", "View Order Details")}
           <ArrowRight className="w-4 h-4 ml-2" />
         </Button>
       </div>
@@ -163,12 +195,26 @@ export const OrderConfirmation = () => {
       <Card>
         <CardContent className="p-6">
           <div className="text-center text-sm text-muted-foreground space-y-2">
-            <p>{t('order.confirmation_email', 'A confirmation email has been sent to your email address.')}</p>
-            <p>{t('order.tracking_info', 'You will receive tracking information once your order ships.')}</p>
-            <p>{t('order.support_message', 'If you have any questions, please contact our customer support.')}</p>
+            <p>
+              {t(
+                "order.confirmation_email",
+                "A confirmation email has been sent to your email address.",
+              )}
+            </p>
+            <p>
+              {t(
+                "order.tracking_info",
+                "You will receive tracking information once your order ships.",
+              )}
+            </p>
+            <p>
+              {t(
+                "order.support_message",
+                "If you have any questions, please contact our customer support.",
+              )}
+            </p>
           </div>
         </CardContent>
       </Card>
     </div>
-  );
-};
+  );};

--- a/ve-shop-frontend/src/components/checkout/PaymentMethod.tsx
+++ b/ve-shop-frontend/src/components/checkout/PaymentMethod.tsx
@@ -10,25 +10,24 @@ import { useCartStore } from "@/store/cartStore";
 import { useNotificationStore } from "@/stores/notificationStore";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
+import { useLanguageStore } from "@/store/languageStore";
 
 export const PaymentMethod = () => {
-  const { t } = useTranslation('cart');
-  const [selectedMethod, setSelectedMethod] = useState('stripe');
+  const { t } = useTranslation("cart");
+  const [selectedMethod, setSelectedMethod] = useState("stripe");
   const [cardData, setCardData] = useState({
-    number: '',
-    expiry: '',
-    cvc: '',
-    name: ''
+    number: "",
+    expiry: "",
+    cvc: "",
+    name: "",
   });
-  
-  const { 
-    setPaymentMethod, 
-    setCheckoutStep, 
-    checkoutData, 
-    addOrder 
-  } = useOrderStore();
+
+  const { setPaymentMethod, setCheckoutStep, checkoutData, addOrder } =
+    useOrderStore();
   const { items, getSubtotal, clearCart } = useCartStore();
   const { addNotification } = useNotificationStore();
+  const { direction } = useLanguageStore();
+  const isRTL = direction === "rtl";
 
   const subtotal = getSubtotal();
   const tax = subtotal * 0.1;
@@ -38,38 +37,47 @@ export const PaymentMethod = () => {
 
   const paymentMethods = [
     {
-      id: 'stripe',
-      name: 'Credit/Debit Card',
-      description: 'Visa, Mastercard, American Express',
-      icon: CreditCard
+      id: "stripe",
+      name: "Credit/Debit Card",
+      description: "Visa, Mastercard, American Express",
+      icon: CreditCard,
     },
     {
-      id: 'paypal',
-      name: 'PayPal',
-      description: 'Pay with your PayPal account',
-      icon: CreditCard
+      id: "paypal",
+      name: "PayPal",
+      description: "Pay with your PayPal account",
+      icon: CreditCard,
     },
     {
-      id: 'apple-pay',
-      name: 'Apple Pay',
-      description: 'Touch ID or Face ID required',
-      icon: CreditCard
-    }
+      id: "apple-pay",
+      name: "Apple Pay",
+      description: "Touch ID or Face ID required",
+      icon: CreditCard,
+    },
   ];
 
   const handlePlaceOrder = async () => {
     if (!checkoutData.shippingAddress) {
-      toast.error(t('checkout.missing_shipping_address', 'Shipping address is required'));
+      toast.error(
+        t("checkout.missing_shipping_address", "Shipping address is required"),
+      );
       return;
     }
 
     if (!selectedMethod) {
-      toast.error(t('checkout.select_payment_method', 'Please select a payment method'));
+      toast.error(
+        t("checkout.select_payment_method", "Please select a payment method"),
+      );
       return;
     }
 
-    if (selectedMethod === 'stripe' && (!cardData.number || !cardData.expiry || !cardData.cvc || !cardData.name)) {
-      toast.error(t('checkout.complete_card_details', 'Please complete card details'));
+    if (
+      selectedMethod === "stripe" &&
+      (!cardData.number || !cardData.expiry || !cardData.cvc || !cardData.name)
+    ) {
+      toast.error(
+        t("checkout.complete_card_details", "Please complete card details"),
+      );
       return;
     }
 
@@ -82,12 +90,14 @@ export const PaymentMethod = () => {
       subtotal,
       tax,
       shipping,
-      status: 'pending',
+      status: "pending",
       shippingAddress: checkoutData.shippingAddress,
       paymentMethod: selectedMethod,
       couponCode: checkoutData.couponCode,
       discount,
-      estimatedDelivery: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString() // 7 days from now
+      estimatedDelivery: new Date(
+        Date.now() + 7 * 24 * 60 * 60 * 1000,
+      ).toISOString(), // 7 days from now
     });
 
     // Clear cart
@@ -95,13 +105,16 @@ export const PaymentMethod = () => {
 
     // Add notification
     addNotification({
-      type: 'success',
-      title: t('checkout.order_placed_successfully', 'Order Placed Successfully'),
-      message: `${t('checkout.order_number', 'Order Number')}: ${order.orderNumber}`,
-      category: 'order'
+      type: "success",
+      title: t(
+        "checkout.order_placed_successfully",
+        "Order Placed Successfully",
+      ),
+      message: `${t("checkout.order_number", "Order Number")}: ${order.orderNumber}`,
+      category: "order",
     });
 
-    toast.success(t('checkout.order_placed_successfully'));
+    toast.success(t("checkout.order_placed_successfully"));
     setCheckoutStep(4);
   };
 
@@ -110,27 +123,40 @@ export const PaymentMethod = () => {
   };
 
   return (
-    <div className="space-y-6">
-      <h2 className="text-xl font-semibold">{t('checkout.payment_method')}</h2>
+    <div dir={direction} className="space-y-6">
+      <h2 className="text-xl font-semibold">{t("checkout.payment_method")}</h2>
 
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
         {/* Payment Methods */}
         <div className="lg:col-span-2 space-y-4">
           <Card>
             <CardHeader>
-              <CardTitle>{t('checkout.select_payment_method', 'Select Payment Method')}</CardTitle>
+              <CardTitle>
+                {t("checkout.select_payment_method", "Select Payment Method")}
+              </CardTitle>
             </CardHeader>
             <CardContent>
-              <RadioGroup value={selectedMethod} onValueChange={setSelectedMethod}>
+              <RadioGroup
+                value={selectedMethod}
+                onValueChange={setSelectedMethod}
+              >
                 {paymentMethods.map((method) => (
-                  <div key={method.id} className="flex items-center space-x-3 p-3 border rounded-lg hover:bg-muted/50">
+                  <div
+                    key={method.id}
+                    className="flex items-center space-x-3 p-3 border rounded-lg hover:bg-muted/50"
+                  >
                     <RadioGroupItem value={method.id} id={method.id} />
-                    <Label htmlFor={method.id} className="flex-1 cursor-pointer">
+                    <Label
+                      htmlFor={method.id}
+                      className="flex-1 cursor-pointer"
+                    >
                       <div className="flex items-center gap-3">
                         <method.icon className="w-5 h-5" />
                         <div>
                           <div className="font-medium">{method.name}</div>
-                          <div className="text-sm text-muted-foreground">{method.description}</div>
+                          <div className="text-sm text-muted-foreground">
+                            {method.description}
+                          </div>
                         </div>
                       </div>
                     </Label>
@@ -141,52 +167,75 @@ export const PaymentMethod = () => {
           </Card>
 
           {/* Card Details Form */}
-          {selectedMethod === 'stripe' && (
+          {selectedMethod === "stripe" && (
             <Card>
               <CardHeader>
                 <CardTitle className="flex items-center gap-2">
                   <Lock className="w-5 h-5" />
-                  {t('checkout.card_details', 'Card Details')}
+                  {t("checkout.card_details", "Card Details")}
                 </CardTitle>
               </CardHeader>
               <CardContent className="space-y-4">
                 <div>
-                  <Label htmlFor="cardName">{t('checkout.cardholder_name', 'Cardholder Name')}</Label>
+                  <Label htmlFor="cardName">
+                    {t("checkout.cardholder_name", "Cardholder Name")}
+                  </Label>
                   <Input
                     id="cardName"
                     placeholder="John Doe"
                     value={cardData.name}
-                    onChange={(e) => setCardData(prev => ({ ...prev, name: e.target.value }))}
+                    onChange={(e) =>
+                      setCardData((prev) => ({ ...prev, name: e.target.value }))
+                    }
                   />
                 </div>
-                
+
                 <div>
-                  <Label htmlFor="cardNumber">{t('checkout.card_number', 'Card Number')}</Label>
+                  <Label htmlFor="cardNumber">
+                    {t("checkout.card_number", "Card Number")}
+                  </Label>
                   <Input
                     id="cardNumber"
                     placeholder="1234 5678 9012 3456"
                     value={cardData.number}
-                    onChange={(e) => setCardData(prev => ({ ...prev, number: e.target.value }))}
+                    onChange={(e) =>
+                      setCardData((prev) => ({
+                        ...prev,
+                        number: e.target.value,
+                      }))
+                    }
                   />
                 </div>
-                
+
                 <div className="grid grid-cols-2 gap-4">
                   <div>
-                    <Label htmlFor="expiry">{t('checkout.expiry_date', 'MM/YY')}</Label>
+                    <Label htmlFor="expiry">
+                      {t("checkout.expiry_date", "MM/YY")}
+                    </Label>
                     <Input
                       id="expiry"
                       placeholder="12/25"
                       value={cardData.expiry}
-                      onChange={(e) => setCardData(prev => ({ ...prev, expiry: e.target.value }))}
+                      onChange={(e) =>
+                        setCardData((prev) => ({
+                          ...prev,
+                          expiry: e.target.value,
+                        }))
+                      }
                     />
                   </div>
                   <div>
-                    <Label htmlFor="cvc">{t('checkout.cvc', 'CVC')}</Label>
+                    <Label htmlFor="cvc">{t("checkout.cvc", "CVC")}</Label>
                     <Input
                       id="cvc"
                       placeholder="123"
                       value={cardData.cvc}
-                      onChange={(e) => setCardData(prev => ({ ...prev, cvc: e.target.value }))}
+                      onChange={(e) =>
+                        setCardData((prev) => ({
+                          ...prev,
+                          cvc: e.target.value,
+                        }))
+                      }
                     />
                   </div>
                 </div>
@@ -198,31 +247,35 @@ export const PaymentMethod = () => {
         {/* Order Summary */}
         <Card>
           <CardHeader>
-            <CardTitle>{t('checkout.order_summary')}</CardTitle>
+            <CardTitle>{t("checkout.order_summary")}</CardTitle>
           </CardHeader>
           <CardContent className="space-y-4">
             <div className="space-y-2">
               <div className="flex justify-between text-sm">
-                <span>{t('cart.subtotal')}</span>
+                <span>{t("cart.subtotal")}</span>
                 <span>${subtotal.toFixed(2)}</span>
               </div>
               <div className="flex justify-between text-sm">
-                <span>{t('cart.shipping')}</span>
-                <span>{shipping === 0 ? t('cart.free', 'Free') : `$${shipping.toFixed(2)}`}</span>
+                <span>{t("cart.shipping")}</span>
+                <span>
+                  {shipping === 0
+                    ? t("cart.free", "Free")
+                    : `$${shipping.toFixed(2)}`}
+                </span>
               </div>
               <div className="flex justify-between text-sm">
-                <span>{t('cart.tax')}</span>
+                <span>{t("cart.tax")}</span>
                 <span>${tax.toFixed(2)}</span>
               </div>
               {discount > 0 && (
                 <div className="flex justify-between text-sm text-green-600">
-                  <span>{t('cart.discount')}</span>
+                  <span>{t("cart.discount")}</span>
                   <span>-${discount.toFixed(2)}</span>
                 </div>
               )}
               <div className="border-t pt-2">
                 <div className="flex justify-between font-semibold">
-                  <span>{t('cart.total')}</span>
+                  <span>{t("cart.total")}</span>
                   <span>${total.toFixed(2)}</span>
                 </div>
               </div>
@@ -231,11 +284,16 @@ export const PaymentMethod = () => {
             {/* Shipping Address Summary */}
             {checkoutData.shippingAddress && (
               <div className="pt-4 border-t">
-                <h4 className="font-medium mb-2">{t('checkout.shipping_to', 'Shipping to:')}</h4>
+                <h4 className="font-medium mb-2">
+                  {t("checkout.shipping_to", "Shipping to:")}
+                </h4>
                 <div className="text-sm text-muted-foreground">
                   <p>{checkoutData.shippingAddress.name}</p>
                   <p>{checkoutData.shippingAddress.street}</p>
-                  <p>{checkoutData.shippingAddress.city}, {checkoutData.shippingAddress.state}</p>
+                  <p>
+                    {checkoutData.shippingAddress.city},{" "}
+                    {checkoutData.shippingAddress.state}
+                  </p>
                 </div>
               </div>
             )}
@@ -245,15 +303,35 @@ export const PaymentMethod = () => {
 
       <div className="flex justify-between pt-6">
         <Button variant="outline" onClick={handleBack}>
-          <ChevronLeft className="w-4 h-4 mr-2" />
-          {t('checkout.back_to_shipping', 'Back to Shipping')}
+          {isRTL ? (
+            <>
+              {t("checkout.back_to_shipping", "Back to Shipping")}
+              <ChevronRight className="w-4 h-4 ml-2" />
+            </>
+          ) : (
+            <>
+              <ChevronLeft className="w-4 h-4 mr-2" />
+              {t("checkout.back_to_shipping", "Back to Shipping")}
+            </>
+          )}
         </Button>
-        
-        <Button onClick={handlePlaceOrder} className="bg-green-600 hover:bg-green-700">
-          <Lock className="w-4 h-4 mr-2" />
-          {t('checkout.place_order')} - ${total.toFixed(2)}
+
+        <Button
+          onClick={handlePlaceOrder}
+          className="bg-green-600 hover:bg-green-700"
+        >
+          {isRTL ? (
+            <>
+              {t("checkout.place_order")} - ${total.toFixed(2)}
+              <Lock className="w-4 h-4 ml-2" />
+            </>
+          ) : (
+            <>
+              <Lock className="w-4 h-4 mr-2" />
+              {t("checkout.place_order")} - ${total.toFixed(2)}
+            </>
+          )}
         </Button>
       </div>
     </div>
-  );
-};
+  );};

--- a/ve-shop-frontend/src/components/checkout/ShippingAddress.tsx
+++ b/ve-shop-frontend/src/components/checkout/ShippingAddress.tsx
@@ -2,18 +2,27 @@ import { useState } from "react";
 import { Plus, Edit, Trash2, ChevronLeft, ChevronRight } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
 import { AddressForm } from "@/components/forms/AddressForm";
 import { useOrderStore, type Address } from "@/stores/orderStore";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
+import { useLanguageStore } from "@/store/languageStore";
 
 export const ShippingAddress = () => {
-  const { t } = useTranslation('cart');
+  const { t } = useTranslation("cart");
   const [selectedAddress, setSelectedAddress] = useState<Address | null>(null);
   const [editingAddress, setEditingAddress] = useState<Address | null>(null);
   const [showAddressForm, setShowAddressForm] = useState(false);
-  
+  const { direction } = useLanguageStore();
+  const isRTL = direction === "rtl";
+
   const {
     addresses,
     addAddress,
@@ -21,7 +30,7 @@ export const ShippingAddress = () => {
     removeAddress,
     setShippingAddress,
     setCheckoutStep,
-    checkoutData
+    checkoutData,
   } = useOrderStore();
 
   const handleSelectAddress = (address: Address) => {
@@ -29,17 +38,21 @@ export const ShippingAddress = () => {
     setShippingAddress(address);
   };
 
-  const handleAddAddress = (addressData: Omit<Address, 'id'>) => {
+  const handleAddAddress = (addressData: Omit<Address, "id">) => {
     addAddress(addressData);
     setShowAddressForm(false);
-    toast.success(t('address.added_successfully', 'Address added successfully'));
+    toast.success(
+      t("address.added_successfully", "Address added successfully"),
+    );
   };
 
-  const handleUpdateAddress = (addressData: Omit<Address, 'id'>) => {
+  const handleUpdateAddress = (addressData: Omit<Address, "id">) => {
     if (editingAddress) {
       updateAddress(editingAddress.id, addressData);
       setEditingAddress(null);
-      toast.success(t('address.updated_successfully', 'Address updated successfully'));
+      toast.success(
+        t("address.updated_successfully", "Address updated successfully"),
+      );
     }
   };
 
@@ -48,12 +61,19 @@ export const ShippingAddress = () => {
     if (selectedAddress?.id === address.id) {
       setSelectedAddress(null);
     }
-    toast.success(t('address.removed_successfully', 'Address removed successfully'));
+    toast.success(
+      t("address.removed_successfully", "Address removed successfully"),
+    );
   };
 
   const handleProceedToPayment = () => {
     if (!selectedAddress) {
-      toast.error(t('checkout.select_shipping_address', 'Please select a shipping address'));
+      toast.error(
+        t(
+          "checkout.select_shipping_address",
+          "Please select a shipping address",
+        ),
+      );
       return;
     }
     setCheckoutStep(3);
@@ -64,20 +84,22 @@ export const ShippingAddress = () => {
   };
 
   return (
-    <div className="space-y-6">
+    <div dir={direction} className="space-y-6">
       <div className="flex items-center justify-between">
-        <h2 className="text-xl font-semibold">{t('checkout.shipping_address')}</h2>
-        
+        <h2 className="text-xl font-semibold">
+          {t("checkout.shipping_address")}
+        </h2>
+
         <Dialog open={showAddressForm} onOpenChange={setShowAddressForm}>
           <DialogTrigger asChild>
             <Button>
               <Plus className="w-4 h-4 mr-2" />
-              {t('address.add_new', 'Add New Address')}
+              {t("address.add_new", "Add New Address")}
             </Button>
           </DialogTrigger>
           <DialogContent>
             <DialogHeader>
-              <DialogTitle>{t('address.add_new')}</DialogTitle>
+              <DialogTitle>{t("address.add_new")}</DialogTitle>
             </DialogHeader>
             <AddressForm
               onSubmit={handleAddAddress}
@@ -91,23 +113,23 @@ export const ShippingAddress = () => {
         <Card>
           <CardContent className="p-8 text-center">
             <p className="text-muted-foreground mb-4">
-              {t('address.no_saved_addresses', 'No saved addresses found')}
+              {t("address.no_saved_addresses", "No saved addresses found")}
             </p>
             <Button onClick={() => setShowAddressForm(true)}>
               <Plus className="w-4 h-4 mr-2" />
-              {t('address.add_first', 'Add Your First Address')}
+              {t("address.add_first", "Add Your First Address")}
             </Button>
           </CardContent>
         </Card>
       ) : (
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           {addresses.map((address) => (
-            <Card 
+            <Card
               key={address.id}
               className={`cursor-pointer transition-colors ${
-                selectedAddress?.id === address.id 
-                  ? 'ring-2 ring-primary bg-primary/5' 
-                  : 'hover:bg-muted/50'
+                selectedAddress?.id === address.id
+                  ? "ring-2 ring-primary bg-primary/5"
+                  : "hover:bg-muted/50"
               }`}
               onClick={() => handleSelectAddress(address)}
             >
@@ -115,9 +137,12 @@ export const ShippingAddress = () => {
                 <div className="flex items-center justify-between">
                   <CardTitle className="text-base">{address.name}</CardTitle>
                   <div className="flex gap-1">
-                    <Dialog open={editingAddress?.id === address.id} onOpenChange={(open) => {
-                      if (!open) setEditingAddress(null);
-                    }}>
+                    <Dialog
+                      open={editingAddress?.id === address.id}
+                      onOpenChange={(open) => {
+                        if (!open) setEditingAddress(null);
+                      }}
+                    >
                       <DialogTrigger asChild>
                         <Button
                           variant="ghost"
@@ -132,7 +157,9 @@ export const ShippingAddress = () => {
                       </DialogTrigger>
                       <DialogContent>
                         <DialogHeader>
-                          <DialogTitle>{t('address.edit', 'Edit Address')}</DialogTitle>
+                          <DialogTitle>
+                            {t("address.edit", "Edit Address")}
+                          </DialogTitle>
                         </DialogHeader>
                         <AddressForm
                           initialData={address}
@@ -141,7 +168,7 @@ export const ShippingAddress = () => {
                         />
                       </DialogContent>
                     </Dialog>
-                    
+
                     <Button
                       variant="ghost"
                       size="icon"
@@ -156,19 +183,25 @@ export const ShippingAddress = () => {
                   </div>
                 </div>
               </CardHeader>
-              
+
               <CardContent className="pt-0">
                 <div className="text-sm text-muted-foreground space-y-1">
                   <p>{address.street}</p>
-                  <p>{address.city}, {address.state} {address.zipCode}</p>
+                  <p>
+                    {address.city}, {address.state} {address.zipCode}
+                  </p>
                   <p>{address.country}</p>
-                  {address.phone && <p>{t('address.phone', 'Phone')}: {address.phone}</p>}
+                  {address.phone && (
+                    <p>
+                      {t("address.phone", "Phone")}: {address.phone}
+                    </p>
+                  )}
                 </div>
-                
+
                 {address.isDefault && (
                   <div className="mt-2">
                     <span className="inline-flex items-center px-2 py-1 rounded-md text-xs font-medium bg-primary/10 text-primary">
-                      {t('address.default', 'Default')}
+                      {t("address.default", "Default")}
                     </span>
                   </div>
                 )}
@@ -180,18 +213,32 @@ export const ShippingAddress = () => {
 
       <div className="flex justify-between pt-6">
         <Button variant="outline" onClick={handleBack}>
-          <ChevronLeft className="w-4 h-4 mr-2" />
-          {t('checkout.back_to_cart', 'Back to Cart')}
+          {isRTL ? (
+            <>
+              {t("checkout.back_to_cart", "Back to Cart")}
+              <ChevronRight className="w-4 h-4 ml-2" />
+            </>
+          ) : (
+            <>
+              <ChevronLeft className="w-4 h-4 mr-2" />
+              {t("checkout.back_to_cart", "Back to Cart")}
+            </>
+          )}
         </Button>
-        
-        <Button 
-          onClick={handleProceedToPayment}
-          disabled={!selectedAddress}
-        >
-          {t('checkout.continue_to_payment', 'Continue to Payment')}
-          <ChevronRight className="w-4 h-4 ml-2" />
+
+        <Button onClick={handleProceedToPayment} disabled={!selectedAddress}>
+          {isRTL ? (
+            <>
+              <ChevronLeft className="w-4 h-4 mr-2" />
+              {t("checkout.continue_to_payment", "Continue to Payment")}
+            </>
+          ) : (
+            <>
+              {t("checkout.continue_to_payment", "Continue to Payment")}
+              <ChevronRight className="w-4 h-4 ml-2" />
+            </>
+          )}
         </Button>
       </div>
     </div>
-  );
-};
+  );};

--- a/ve-shop-frontend/src/components/layout/Header.tsx
+++ b/ve-shop-frontend/src/components/layout/Header.tsx
@@ -28,6 +28,7 @@ export const Header = () => {
   return (
     <header
       dir={direction}
+      role="banner"
       className="sticky top-0 z-50 bg-background/95 backdrop-blur-sm border-b border-border"
     >
       {/* Top bar with promotions */}
@@ -151,6 +152,7 @@ export const Header = () => {
         {/* Navigation Bar */}
         <nav
           dir={direction}
+          role="navigation"
           className={cn(
             "hidden md:flex items-center gap-4 sm:gap-6 mt-4 pt-4 border-t border-border text-base",
             isRTL ? "flex-row-reverse" : "flex-row",


### PR DESCRIPTION
## Summary
- add `useLanguageStore` direction logic to checkout components
- swap icons and adjust margins for RTL vs LTR
- add `role` attributes to Header for accessibility

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npx prettier -w src/components/checkout/CartReview.tsx src/components/checkout/CheckoutSteps.tsx src/components/checkout/OrderConfirmation.tsx src/components/checkout/PaymentMethod.tsx src/components/checkout/ShippingAddress.tsx src/components/layout/Header.tsx`

------
https://chatgpt.com/codex/tasks/task_e_686df332d3e08330a116eb674bd80b2f