### PR TITLE
Add demo catalog data and new pages

### DIFF
--- a/ve-shop-frontend/README.md
+++ b/ve-shop-frontend/README.md
@@ -517,6 +517,12 @@ const categories = [
 // 3. Add category-specific filters
 ```
 
+### Managing Demo Products
+
+Demo categories and products are stored in the Zustand store located at `src/store/catalogStore.ts`.
+You can easily modify the initial arrays or use the provided `addCategory` and `addProduct` methods to
+extend the catalog. This setup keeps the data in-memory and makes it simple to replace with a real API later.
+
 ### Customizing Theme
 ```css
 /* Override design tokens */

--- a/ve-shop-frontend/src/App.tsx
+++ b/ve-shop-frontend/src/App.tsx
@@ -15,6 +15,12 @@ const Auth = lazy(() => import("./pages/Auth"));
 const Profile = lazy(() => import("./pages/Profile"));
 const Checkout = lazy(() => import("./pages/Checkout"));
 const ProductDetail = lazy(() => import("./pages/ProductDetail"));
+const Categories = lazy(() => import("./pages/Categories"));
+const CategoryProducts = lazy(() => import("./pages/CategoryProducts"));
+const Products = lazy(() => import("./pages/Products"));
+const Cart = lazy(() => import("./pages/Cart"));
+const About = lazy(() => import("./pages/About"));
+const Contact = lazy(() => import("./pages/Contact"));
 const NotFound = lazy(() => import("./pages/NotFound"));
 
 const queryClient = new QueryClient();
@@ -45,6 +51,12 @@ const App = () => {
                       <Route path="/profile" element={<Profile />} />
                       <Route path="/checkout" element={<Checkout />} />
                       <Route path="/product/:id" element={<ProductDetail />} />
+                      <Route path="/products" element={<Products />} />
+                      <Route path="/cart" element={<Cart />} />
+                      <Route path="/categories" element={<Categories />} />
+                      <Route path="/categories/:id" element={<CategoryProducts />} />
+                      <Route path="/about" element={<About />} />
+                      <Route path="/contact" element={<Contact />} />
                       {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
                       <Route path="*" element={<NotFound />} />
                     </Routes>

--- a/ve-shop-frontend/src/components/layout/CategoryNav.tsx
+++ b/ve-shop-frontend/src/components/layout/CategoryNav.tsx
@@ -1,23 +1,19 @@
 import { Button } from "@/components/ui/button";
 import { useTranslation } from "react-i18next";
 import { useLanguageStore } from "@/store/languageStore";
+import { useCatalogStore } from "@/store/catalogStore";
 import { cn } from "@/lib/utils";
 
-export const CategoryNav = () => {
+interface CategoryNavProps {
+  selected?: string;
+  onSelect?: (id: string) => void;
+}
+
+export const CategoryNav = ({ selected = "all", onSelect }: CategoryNavProps) => {
   const { t } = useTranslation('common');
   const { direction } = useLanguageStore();
+  const categories = useCatalogStore((state) => state.categories);
   const isRTL = direction === "rtl";
-  
-  const categories = [
-    { key: "all", icon: "🛍️", active: true },
-    { key: "electronics", icon: "📱", active: false },
-    { key: "fashion", icon: "👕", active: false },
-    { key: "home", icon: "🏠", active: false },
-    { key: "sports", icon: "⚽", active: false },
-    { key: "beauty", icon: "💄", active: false },
-    { key: "books", icon: "📚", active: false },
-    { key: "toys", icon: "🎮", active: false }
-  ];
 
   return (
     <section 
@@ -38,25 +34,42 @@ export const CategoryNav = () => {
         </div>
         
         <div className="grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-8 gap-4">
+          <Button
+            key="all"
+            variant={selected === 'all' ? 'default' : 'outline'}
+            className={cn(
+              'h-auto p-4 flex flex-col items-center gap-2 transition-all duration-normal',
+              selected === 'all'
+                ? 'bg-primary text-primary-foreground shadow-md'
+                : 'hover:bg-primary/10 hover:border-primary hover:text-primary'
+            )}
+            onClick={() => onSelect?.('all')}
+          >
+            <span className="text-2xl">🛍️</span>
+            <span className="text-sm font-medium text-center">
+              {t('categories.all')}
+            </span>
+          </Button>
+
           {categories.map((category) => (
             <Button
-              key={category.key}
-              variant={category.active ? "default" : "outline"}
+              key={category.id}
+              variant={selected === category.id ? 'default' : 'outline'}
               className={cn(
-                "h-auto p-4 flex flex-col items-center gap-2 transition-all duration-normal",
-                category.active 
-                  ? 'bg-primary text-primary-foreground shadow-md' 
+                'h-auto p-4 flex flex-col items-center gap-2 transition-all duration-normal',
+                selected === category.id
+                  ? 'bg-primary text-primary-foreground shadow-md'
                   : 'hover:bg-primary/10 hover:border-primary hover:text-primary'
               )}
+              onClick={() => onSelect?.(category.id)}
             >
               <span className="text-2xl">{category.icon}</span>
               <span className="text-sm font-medium text-center">
-                {t(`categories.${category.key}`)}
+                {category.name}
               </span>
             </Button>
           ))}
         </div>
       </div>
     </section>
-  );
-};
+  );};

--- a/ve-shop-frontend/src/components/products/CategorySidebar.tsx
+++ b/ve-shop-frontend/src/components/products/CategorySidebar.tsx
@@ -1,17 +1,7 @@
-import { useState } from "react";
-import { ChevronDown, ChevronRight } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { useTranslation } from "react-i18next";
-
-interface CategoryItem {
-  id: string;
-  name: string;
-  icon: string;
-  count?: number;
-  subcategories?: CategoryItem[];
-}
+import { useCatalogStore } from "@/store/catalogStore";
 
 interface CategorySidebarProps {
   onCategorySelect?: (categoryId: string) => void;
@@ -20,67 +10,7 @@ interface CategorySidebarProps {
 
 export const CategorySidebar = ({ onCategorySelect, selectedCategory }: CategorySidebarProps) => {
   const { t } = useTranslation('common');
-  const [openCategories, setOpenCategories] = useState<string[]>(['electronics']);
-
-  const categories: CategoryItem[] = [
-    {
-      id: 'electronics',
-      name: t('categories.electronics'),
-      icon: '📱',
-      count: 1250,
-      subcategories: [
-        { id: 'smartphones', name: 'Smartphones', icon: '📱', count: 320 },
-        { id: 'laptops', name: 'Laptops', icon: '💻', count: 180 },
-        { id: 'headphones', name: 'Headphones', icon: '🎧', count: 95 },
-        { id: 'cameras', name: 'Cameras', icon: '📷', count: 75 },
-        { id: 'gaming', name: 'Gaming', icon: '🎮', count: 140 },
-      ]
-    },
-    {
-      id: 'fashion',
-      name: t('categories.fashion'),
-      icon: '👕',
-      count: 2100,
-      subcategories: [
-        { id: 'mens-clothing', name: "Men's Clothing", icon: '👔', count: 580 },
-        { id: 'womens-clothing', name: "Women's Clothing", icon: '👗', count: 920 },
-        { id: 'shoes', name: 'Shoes', icon: '👟', count: 340 },
-        { id: 'accessories', name: 'Accessories', icon: '👜', count: 260 },
-      ]
-    },
-    {
-      id: 'home',
-      name: t('categories.home'),
-      icon: '🏠',
-      count: 890,
-      subcategories: [
-        { id: 'furniture', name: 'Furniture', icon: '🪑', count: 240 },
-        { id: 'kitchen', name: 'Kitchen', icon: '🍳', count: 180 },
-        { id: 'decor', name: 'Home Decor', icon: '🖼️', count: 150 },
-        { id: 'garden', name: 'Garden', icon: '🌱', count: 120 },
-      ]
-    },
-    {
-      id: 'sports',
-      name: t('categories.sports'),
-      icon: '⚽',
-      count: 560,
-      subcategories: [
-        { id: 'fitness', name: 'Fitness', icon: '💪', count: 180 },
-        { id: 'outdoor', name: 'Outdoor', icon: '🏕️', count: 140 },
-        { id: 'team-sports', name: 'Team Sports', icon: '⚽', count: 120 },
-        { id: 'water-sports', name: 'Water Sports', icon: '🏄', count: 80 },
-      ]
-    }
-  ];
-
-  const toggleCategory = (categoryId: string) => {
-    setOpenCategories(prev => 
-      prev.includes(categoryId) 
-        ? prev.filter(id => id !== categoryId)
-        : [...prev, categoryId]
-    );
-  };
+  const categories = useCatalogStore((state) => state.categories);
 
   const handleCategoryClick = (categoryId: string) => {
     onCategorySelect?.(categoryId);
@@ -95,7 +25,6 @@ export const CategorySidebar = ({ onCategorySelect, selectedCategory }: Category
       </CardHeader>
       <CardContent className="p-0">
         <div className="space-y-1">
-          {/* All Products option */}
           <Button
             variant="ghost"
             className={`w-full justify-start px-4 py-3 h-auto ${
@@ -107,59 +36,20 @@ export const CategorySidebar = ({ onCategorySelect, selectedCategory }: Category
             <span className="flex-1 text-left">{t('categories.all')}</span>
           </Button>
 
-          {/* Category list */}
           {categories.map((category) => (
-            <Collapsible
+            <Button
               key={category.id}
-              open={openCategories.includes(category.id)}
-              onOpenChange={() => toggleCategory(category.id)}
+              variant="ghost"
+              className={`w-full justify-start px-4 py-3 h-auto ${
+                selectedCategory === category.id ? 'bg-primary/10 text-primary' : ''
+              }`}
+              onClick={() => handleCategoryClick(category.id)}
             >
-              <CollapsibleTrigger asChild>
-                <Button
-                  variant="ghost"
-                  className={`w-full justify-start px-4 py-3 h-auto ${
-                    selectedCategory === category.id ? 'bg-primary/10 text-primary' : ''
-                  }`}
-                >
-                  <span className="text-lg mr-3">{category.icon}</span>
-                  <span className="flex-1 text-left">{category.name}</span>
-                  <span className="text-xs text-muted-foreground mr-2">
-                    {category.count}
-                  </span>
-                  {category.subcategories && (
-                    openCategories.includes(category.id) ? (
-                      <ChevronDown className="w-4 h-4" />
-                    ) : (
-                      <ChevronRight className="w-4 h-4" />
-                    )
-                  )}
-                </Button>
-              </CollapsibleTrigger>
-              
-              {category.subcategories && (
-                <CollapsibleContent className="pl-4">
-                  {category.subcategories.map((subcategory) => (
-                    <Button
-                      key={subcategory.id}
-                      variant="ghost"
-                      className={`w-full justify-start px-4 py-2 h-auto text-sm ${
-                        selectedCategory === subcategory.id ? 'bg-primary/10 text-primary' : ''
-                      }`}
-                      onClick={() => handleCategoryClick(subcategory.id)}
-                    >
-                      <span className="mr-3">{subcategory.icon}</span>
-                      <span className="flex-1 text-left">{subcategory.name}</span>
-                      <span className="text-xs text-muted-foreground">
-                        {subcategory.count}
-                      </span>
-                    </Button>
-                  ))}
-                </CollapsibleContent>
-              )}
-            </Collapsible>
+              <span className="text-lg mr-3">{category.icon}</span>
+              <span className="flex-1 text-left">{category.name}</span>
+            </Button>
           ))}
         </div>
       </CardContent>
     </Card>
-  );
-};
+  );};

--- a/ve-shop-frontend/src/components/products/DealsCarousel.tsx
+++ b/ve-shop-frontend/src/components/products/DealsCarousel.tsx
@@ -1,0 +1,26 @@
+import { useCatalogStore } from "@/store/catalogStore";
+import { Carousel, CarouselContent, CarouselItem, CarouselNext, CarouselPrevious } from "@/components/ui/carousel";
+import { ProductCard } from "./ProductCard";
+
+export const DealsCarousel = () => {
+  const products = useCatalogStore((state) => state.products.slice(0, 8));
+
+  return (
+    <section className="py-16 bg-muted/30">
+      <div className="container mx-auto px-4 relative">
+        <h2 className="text-3xl font-bold mb-6 text-center">Top Deals</h2>
+        <Carousel className="overflow-visible">
+          <CarouselContent className="-ml-4">
+            {products.map((product) => (
+              <CarouselItem key={product.id} className="pl-4 basis-1/2 md:basis-1/3 lg:basis-1/4">
+                <ProductCard {...product} />
+              </CarouselItem>
+            ))}
+          </CarouselContent>
+          <CarouselPrevious />
+          <CarouselNext />
+        </Carousel>
+      </div>
+    </section>
+  );
+};

--- a/ve-shop-frontend/src/components/products/ProductGrid.tsx
+++ b/ve-shop-frontend/src/components/products/ProductGrid.tsx
@@ -1,93 +1,19 @@
 import { ProductCard } from "./ProductCard";
+import { useCatalogStore } from "@/store/catalogStore";
 
-const mockProducts = [
-  {
-    id: "1",
-    name: "Wireless Bluetooth Headphones with Active Noise Cancellation",
-    price: 89.99,
-    originalPrice: 129.99,
-    rating: 4.5,
-    reviewCount: 1247,
-    image: "https://images.unsplash.com/photo-1505740420928-5e560c06d30e?w=400&h=400&fit=crop",
-    badge: "Best Seller",
-    isOnSale: true
-  },
-  {
-    id: "2", 
-    name: "Smart Fitness Watch with Heart Rate Monitor",
-    price: 199.99,
-    rating: 4.8,
-    reviewCount: 892,
-    image: "https://images.unsplash.com/photo-1523275335684-37898b6baf30?w=400&h=400&fit=crop",
-    badge: "New"
-  },
-  {
-    id: "3",
-    name: "Professional Camera Lens 50mm f/1.8",
-    price: 299.99,
-    originalPrice: 349.99,
-    rating: 4.7,
-    reviewCount: 456,
-    image: "https://images.unsplash.com/photo-1606983340126-99ab4feaa64a?w=400&h=400&fit=crop",
-    isOnSale: true
-  },
-  {
-    id: "4",
-    name: "Ergonomic Office Chair with Lumbar Support",
-    price: 349.99,
-    rating: 4.6,
-    reviewCount: 234,
-    image: "https://images.unsplash.com/photo-1586023492125-27b2c045efd7?w=400&h=400&fit=crop"
-  },
-  {
-    id: "5",
-    name: "Premium Coffee Machine with Milk Frother",
-    price: 449.99,
-    originalPrice: 549.99,
-    rating: 4.9,
-    reviewCount: 1089,
-    image: "https://images.unsplash.com/photo-1559056199-641a0ac8b55e?w=400&h=400&fit=crop",
-    badge: "Editor's Choice",
-    isOnSale: true
-  },
-  {
-    id: "6",
-    name: "Mechanical Gaming Keyboard RGB Backlit",
-    price: 129.99,
-    rating: 4.4,
-    reviewCount: 678,
-    image: "https://images.unsplash.com/photo-1587829741301-dc798b83add3?w=400&h=400&fit=crop"
-  },
-  {
-    id: "7",
-    name: "Wireless Phone Charger Stand Fast Charging",
-    price: 39.99,
-    originalPrice: 59.99,
-    rating: 4.3,
-    reviewCount: 145,
-    image: "https://images.unsplash.com/photo-1609592669905-a3e7c959a401?w=400&h=400&fit=crop",
-    isOnSale: true
-  },
-  {
-    id: "8",
-    name: "Smart Home Security Camera 1080p WiFi",
-    price: 79.99,
-    rating: 4.5,
-    reviewCount: 567,
-    image: "https://images.unsplash.com/photo-1558618666-fcd25c85cd64?w=400&h=400&fit=crop",
-    badge: "Trending"
-  }
-];
+interface ProductGridProps {
+  categoryId?: string;
+}
 
-export const ProductGrid = () => {
+export const ProductGrid = ({ categoryId = "all" }: ProductGridProps) => {
+  const products = useCatalogStore((state) =>
+    state.getProductsByCategory(categoryId)
+  );
+
   return (
     <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
-      {mockProducts.map((product) => (
-        <ProductCard
-          key={product.id}
-          {...product}
-        />
+      {products.map((product) => (
+        <ProductCard key={product.id} {...product} />
       ))}
     </div>
-  );
-};
+  );};

--- a/ve-shop-frontend/src/pages/About.tsx
+++ b/ve-shop-frontend/src/pages/About.tsx
@@ -1,0 +1,22 @@
+import { Header } from "@/components/layout/Header";
+import { Footer } from "@/components/layout/Footer";
+import { useLanguageStore } from "@/store/languageStore";
+
+const About = () => {
+  const { direction } = useLanguageStore();
+  return (
+    <div className="min-h-screen bg-background" dir={direction}>
+      <Header />
+      <main className="py-8 container mx-auto px-4 prose dark:prose-invert">
+        <h1>About Us</h1>
+        <p>
+          Ve-Shop is a demo e-commerce platform built with React and TailwindCSS.
+          It showcases a modern component architecture with full RTL and dark mode support.
+        </p>
+      </main>
+      <Footer />
+    </div>
+  );
+};
+
+export default About;

--- a/ve-shop-frontend/src/pages/Cart.tsx
+++ b/ve-shop-frontend/src/pages/Cart.tsx
@@ -1,0 +1,19 @@
+import { Header } from "@/components/layout/Header";
+import { Footer } from "@/components/layout/Footer";
+import { CartReview } from "@/components/checkout/CartReview";
+import { useLanguageStore } from "@/store/languageStore";
+
+const Cart = () => {
+  const { direction } = useLanguageStore();
+  return (
+    <div className="min-h-screen bg-background" dir={direction}>
+      <Header />
+      <main className="py-8 container mx-auto px-4">
+        <CartReview />
+      </main>
+      <Footer />
+    </div>
+  );
+};
+
+export default Cart;

--- a/ve-shop-frontend/src/pages/Categories.tsx
+++ b/ve-shop-frontend/src/pages/Categories.tsx
@@ -1,0 +1,34 @@
+import { Header } from "@/components/layout/Header";
+import { Footer } from "@/components/layout/Footer";
+import { useCatalogStore } from "@/store/catalogStore";
+import { useNavigate } from "react-router-dom";
+import { useLanguageStore } from "@/store/languageStore";
+
+const Categories = () => {
+  const categories = useCatalogStore((state) => state.categories);
+  const { direction } = useLanguageStore();
+  const navigate = useNavigate();
+
+  return (
+    <div className="min-h-screen bg-background" dir={direction}>
+      <Header />
+      <main className="py-8">
+        <div className="container mx-auto px-4 grid grid-cols-2 sm:grid-cols-3 md:grid-cols-5 gap-4">
+          {categories.map((cat) => (
+            <button
+              key={cat.id}
+              onClick={() => navigate(`/categories/${cat.id}`)}
+              className="p-4 border rounded-lg flex flex-col items-center hover:bg-muted transition-colors"
+            >
+              <span className="text-3xl mb-2">{cat.icon}</span>
+              <span className="font-medium">{cat.name}</span>
+            </button>
+          ))}
+        </div>
+      </main>
+      <Footer />
+    </div>
+  );
+};
+
+export default Categories;

--- a/ve-shop-frontend/src/pages/CategoryProducts.tsx
+++ b/ve-shop-frontend/src/pages/CategoryProducts.tsx
@@ -1,0 +1,22 @@
+import { Header } from "@/components/layout/Header";
+import { Footer } from "@/components/layout/Footer";
+import { ProductGrid } from "@/components/products/ProductGrid";
+import { useParams } from "react-router-dom";
+import { useLanguageStore } from "@/store/languageStore";
+
+const CategoryProducts = () => {
+  const { id } = useParams();
+  const { direction } = useLanguageStore();
+
+  return (
+    <div className="min-h-screen bg-background" dir={direction}>
+      <Header />
+      <main className="py-8 container mx-auto px-4">
+        <ProductGrid categoryId={id || 'all'} />
+      </main>
+      <Footer />
+    </div>
+  );
+};
+
+export default CategoryProducts;

--- a/ve-shop-frontend/src/pages/Contact.tsx
+++ b/ve-shop-frontend/src/pages/Contact.tsx
@@ -1,0 +1,21 @@
+import { Header } from "@/components/layout/Header";
+import { Footer } from "@/components/layout/Footer";
+import { useLanguageStore } from "@/store/languageStore";
+
+const Contact = () => {
+  const { direction } = useLanguageStore();
+  return (
+    <div className="min-h-screen bg-background" dir={direction}>
+      <Header />
+      <main className="py-8 container mx-auto px-4 prose dark:prose-invert">
+        <h1>Contact Us</h1>
+        <p>
+          For any inquiries please email <a href="mailto:info@example.com">info@example.com</a>.
+        </p>
+      </main>
+      <Footer />
+    </div>
+  );
+};
+
+export default Contact;

--- a/ve-shop-frontend/src/pages/Index.tsx
+++ b/ve-shop-frontend/src/pages/Index.tsx
@@ -3,6 +3,7 @@ import { Header } from "@/components/layout/Header";
 import { HeroSection } from "@/components/layout/HeroSection";
 import { CategoryNav } from "@/components/layout/CategoryNav";
 import { FeaturedSection } from "@/components/products/FeaturedSection";
+import { DealsCarousel } from "@/components/products/DealsCarousel";
 import { ProductGrid } from "@/components/products/ProductGrid";
 import { CategorySidebar } from "@/components/products/CategorySidebar";
 import { ProductFilters } from "@/components/products/ProductFilters";
@@ -18,7 +19,8 @@ const Index = () => {
       <Header />
       <main>
         <HeroSection />
-        <CategoryNav />
+        <CategoryNav selected={selectedCategory} onSelect={setSelectedCategory} />
+        <DealsCarousel />
         <FeaturedSection />
         
         <section className="py-16 bg-muted/30">
@@ -44,7 +46,7 @@ const Index = () => {
               
               {/* Main content */}
               <div className="flex-1">
-                <ProductGrid />
+                <ProductGrid categoryId={selectedCategory} />
               </div>
             </div>
           </div>

--- a/ve-shop-frontend/src/pages/Products.tsx
+++ b/ve-shop-frontend/src/pages/Products.tsx
@@ -1,0 +1,33 @@
+import { useState } from "react";
+import { Header } from "@/components/layout/Header";
+import { Footer } from "@/components/layout/Footer";
+import { CategorySidebar } from "@/components/products/CategorySidebar";
+import { ProductGrid } from "@/components/products/ProductGrid";
+import { useLanguageStore } from "@/store/languageStore";
+
+const Products = () => {
+  const { direction } = useLanguageStore();
+  const [selectedCategory, setSelectedCategory] = useState<string>('all');
+
+  return (
+    <div className="min-h-screen bg-background" dir={direction}>
+      <Header />
+      <main className="py-8">
+        <div className="container mx-auto px-4 flex gap-6">
+          <div className="hidden lg:block">
+            <CategorySidebar
+              selectedCategory={selectedCategory}
+              onCategorySelect={setSelectedCategory}
+            />
+          </div>
+          <div className="flex-1">
+            <ProductGrid categoryId={selectedCategory} />
+          </div>
+        </div>
+      </main>
+      <Footer />
+    </div>
+  );
+};
+
+export default Products;

--- a/ve-shop-frontend/src/store/catalogStore.ts
+++ b/ve-shop-frontend/src/store/catalogStore.ts
@@ -1,0 +1,320 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+export interface Category {
+  id: string;
+  name: string;
+  icon?: string;
+}
+
+export interface Product {
+  id: string;
+  categoryId: string;
+  name: string;
+  price: number;
+  originalPrice?: number;
+  rating: number;
+  reviewCount: number;
+  image: string;
+  description?: string;
+  stock?: number;
+  badge?: string;
+  isOnSale?: boolean;
+}
+
+interface CatalogState {
+  categories: Category[];
+  products: Product[];
+  addCategory: (category: Category) => void;
+  updateCategory: (id: string, data: Partial<Category>) => void;
+  removeCategory: (id: string) => void;
+  addProduct: (product: Product) => void;
+  updateProduct: (id: string, data: Partial<Product>) => void;
+  removeProduct: (id: string) => void;
+  getProductsByCategory: (id: string) => Product[];
+}
+
+const initialCategories: Category[] = [
+  { id: 'electronics', name: 'Electronics', icon: '📱' },
+  { id: 'fashion', name: 'Fashion', icon: '👕' },
+  { id: 'beauty', name: 'Beauty', icon: '💄' },
+  { id: 'home', name: 'Home', icon: '🏠' },
+  { id: 'sports', name: 'Sports', icon: '⚽' }
+];
+
+const initialProducts: Product[] = [
+  // Electronics
+  {
+    id: 'e1',
+    categoryId: 'electronics',
+    name: 'Wireless Bluetooth Headphones',
+    price: 89.99,
+    originalPrice: 129.99,
+    rating: 4.5,
+    reviewCount: 1247,
+    image: 'https://images.unsplash.com/photo-1505740420928-5e560c06d30e?w=400&h=400&fit=crop',
+    isOnSale: true
+  },
+  {
+    id: 'e2',
+    categoryId: 'electronics',
+    name: 'Smart Fitness Watch',
+    price: 199.99,
+    rating: 4.8,
+    reviewCount: 892,
+    image: 'https://images.unsplash.com/photo-1523275335684-37898b6baf30?w=400&h=400&fit=crop',
+    badge: 'New'
+  },
+  {
+    id: 'e3',
+    categoryId: 'electronics',
+    name: 'Professional Camera Lens 50mm',
+    price: 299.99,
+    originalPrice: 349.99,
+    rating: 4.7,
+    reviewCount: 456,
+    image: 'https://images.unsplash.com/photo-1606983340126-99ab4feaa64a?w=400&h=400&fit=crop',
+    isOnSale: true
+  },
+  {
+    id: 'e4',
+    categoryId: 'electronics',
+    name: 'Ergonomic Office Chair',
+    price: 349.99,
+    rating: 4.6,
+    reviewCount: 234,
+    image: 'https://images.unsplash.com/photo-1586023492125-27b2c045efd7?w=400&h=400&fit=crop'
+  },
+  {
+    id: 'e5',
+    categoryId: 'electronics',
+    name: 'Mechanical Gaming Keyboard',
+    price: 129.99,
+    rating: 4.4,
+    reviewCount: 678,
+    image: 'https://images.unsplash.com/photo-1587829741301-dc798b83add3?w=400&h=400&fit=crop'
+  },
+  // Fashion
+  {
+    id: 'f1',
+    categoryId: 'fashion',
+    name: "Men's Classic T-Shirt",
+    price: 19.99,
+    rating: 4.2,
+    reviewCount: 245,
+    image: 'https://images.unsplash.com/photo-1528701800489-20be14fdd017?w=400&h=400&fit=crop'
+  },
+  {
+    id: 'f2',
+    categoryId: 'fashion',
+    name: "Women's Summer Dress",
+    price: 39.99,
+    rating: 4.5,
+    reviewCount: 532,
+    image: 'https://images.unsplash.com/photo-1520975629995-31cb91a3d221?w=400&h=400&fit=crop'
+  },
+  {
+    id: 'f3',
+    categoryId: 'fashion',
+    name: 'Stylish Sunglasses',
+    price: 59.99,
+    rating: 4.7,
+    reviewCount: 312,
+    image: 'https://images.unsplash.com/photo-1517336714731-489689fd1ca8?w=400&h=400&fit=crop'
+  },
+  {
+    id: 'f4',
+    categoryId: 'fashion',
+    name: 'Leather Handbag',
+    price: 129.99,
+    rating: 4.6,
+    reviewCount: 421,
+    image: 'https://images.unsplash.com/photo-1585386959984-a4155223168d?w=400&h=400&fit=crop'
+  },
+  {
+    id: 'f5',
+    categoryId: 'fashion',
+    name: 'Running Sneakers',
+    price: 89.99,
+    rating: 4.4,
+    reviewCount: 289,
+    image: 'https://images.unsplash.com/photo-1519741493539-3735319b6329?w=400&h=400&fit=crop'
+  },
+  // Beauty
+  {
+    id: 'b1',
+    categoryId: 'beauty',
+    name: 'Luxury Lipstick',
+    price: 29.99,
+    rating: 4.8,
+    reviewCount: 542,
+    image: 'https://images.unsplash.com/photo-1522337690853-ac6a0df226c6?w=400&h=400&fit=crop'
+  },
+  {
+    id: 'b2',
+    categoryId: 'beauty',
+    name: 'Moisturizing Face Cream',
+    price: 39.99,
+    rating: 4.9,
+    reviewCount: 764,
+    image: 'https://images.unsplash.com/photo-1504198453319-5ce911bafcde?w=400&h=400&fit=crop'
+  },
+  {
+    id: 'b3',
+    categoryId: 'beauty',
+    name: 'Perfume Spray 50ml',
+    price: 59.99,
+    rating: 4.7,
+    reviewCount: 312,
+    image: 'https://images.unsplash.com/photo-1517849845537-4d257902454a?w=400&h=400&fit=crop'
+  },
+  {
+    id: 'b4',
+    categoryId: 'beauty',
+    name: 'Mascara Volume Plus',
+    price: 24.99,
+    rating: 4.3,
+    reviewCount: 188,
+    image: 'https://images.unsplash.com/photo-1585144576563-5b4c8bf78480?w=400&h=400&fit=crop'
+  },
+  {
+    id: 'b5',
+    categoryId: 'beauty',
+    name: 'Essential Makeup Brush Set',
+    price: 49.99,
+    rating: 4.6,
+    reviewCount: 236,
+    image: 'https://images.unsplash.com/photo-1526045478516-99145907023c?w=400&h=400&fit=crop'
+  },
+  // Home
+  {
+    id: 'h1',
+    categoryId: 'home',
+    name: 'Cozy Throw Blanket',
+    price: 34.99,
+    rating: 4.5,
+    reviewCount: 445,
+    image: 'https://images.unsplash.com/photo-1556911264-5f1b0c69f5b4?w=400&h=400&fit=crop'
+  },
+  {
+    id: 'h2',
+    categoryId: 'home',
+    name: 'Modern Table Lamp',
+    price: 59.99,
+    rating: 4.6,
+    reviewCount: 367,
+    image: 'https://images.unsplash.com/photo-1524758631624-e2822e304c36?w=400&h=400&fit=crop'
+  },
+  {
+    id: 'h3',
+    categoryId: 'home',
+    name: 'Kitchen Knife Set',
+    price: 79.99,
+    rating: 4.7,
+    reviewCount: 512,
+    image: 'https://images.unsplash.com/photo-1586201375754-1001c3276295?w=400&h=400&fit=crop'
+  },
+  {
+    id: 'h4',
+    categoryId: 'home',
+    name: 'Decorative Plant Pot',
+    price: 24.99,
+    rating: 4.4,
+    reviewCount: 221,
+    image: 'https://images.unsplash.com/photo-1499951360447-b19be8fe80f5?w=400&h=400&fit=crop'
+  },
+  {
+    id: 'h5',
+    categoryId: 'home',
+    name: 'Memory Foam Pillow',
+    price: 49.99,
+    rating: 4.8,
+    reviewCount: 654,
+    image: 'https://images.unsplash.com/photo-1567016551804-818c9886f0b5?w=400&h=400&fit=crop'
+  },
+  // Sports
+  {
+    id: 's1',
+    categoryId: 'sports',
+    name: 'Yoga Mat Pro',
+    price: 29.99,
+    rating: 4.6,
+    reviewCount: 342,
+    image: 'https://images.unsplash.com/photo-1599058917212-d750089bc06f?w=400&h=400&fit=crop'
+  },
+  {
+    id: 's2',
+    categoryId: 'sports',
+    name: 'Mountain Bike Helmet',
+    price: 79.99,
+    rating: 4.7,
+    reviewCount: 198,
+    image: 'https://images.unsplash.com/photo-1519681393784-d120267933ba?w=400&h=400&fit=crop'
+  },
+  {
+    id: 's3',
+    categoryId: 'sports',
+    name: 'Adjustable Dumbbell Set',
+    price: 149.99,
+    rating: 4.8,
+    reviewCount: 421,
+    image: 'https://images.unsplash.com/photo-1599058916933-aa33df2004a0?w=400&h=400&fit=crop'
+  },
+  {
+    id: 's4',
+    categoryId: 'sports',
+    name: 'Football Ball Professional',
+    price: 34.99,
+    rating: 4.5,
+    reviewCount: 245,
+    image: 'https://images.unsplash.com/photo-1521412644187-c49fa049e84d?w=400&h=400&fit=crop'
+  },
+  {
+    id: 's5',
+    categoryId: 'sports',
+    name: 'Outdoor Camping Tent',
+    price: 199.99,
+    rating: 4.7,
+    reviewCount: 312,
+    image: 'https://images.unsplash.com/photo-1504280390368-361c6d9f38f4?w=400&h=400&fit=crop'
+  }
+];
+
+export const useCatalogStore = create<CatalogState>()(
+  persist(
+    (set, get) => ({
+      categories: initialCategories,
+      products: initialProducts,
+      addCategory: (category) =>
+        set((state) => ({ categories: [...state.categories, category] })),
+      updateCategory: (id, data) =>
+        set((state) => ({
+          categories: state.categories.map((c) =>
+            c.id === id ? { ...c, ...data } : c
+          ),
+        })),
+      removeCategory: (id) =>
+        set((state) => ({
+          categories: state.categories.filter((c) => c.id !== id),
+          products: state.products.filter((p) => p.categoryId !== id),
+        })),
+      addProduct: (product) =>
+        set((state) => ({ products: [...state.products, product] })),
+      updateProduct: (id, data) =>
+        set((state) => ({
+          products: state.products.map((p) =>
+            p.id === id ? { ...p, ...data } : p
+          ),
+        })),
+      removeProduct: (id) =>
+        set((state) => ({
+          products: state.products.filter((p) => p.id !== id),
+        })),
+      getProductsByCategory: (id) => {
+        if (id === 'all') return get().products;
+        return get().products.filter((p) => p.categoryId === id);
+      },
+    }),
+    { name: 've-shop-catalog' }
+  )
+);


### PR DESCRIPTION
## Summary
- implement `catalogStore` with demo categories and products
- update product grid and category navigation to use store
- simplify category sidebar
- add deals carousel component on home page
- create pages for products, categories, cart, about, and contact
- wire new routes in `App.tsx`
- document demo data management in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686e1bf7038c8330a490c283a6ddbbd4