### PR TITLE
Add dynamic GitHub Pages base detection

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Node.js Environment
         uses: actions/setup-node@v3
         with:
-          node-version: '20.18.3'
+          node-version: "20.18.3"
 
       - name: Install dependencies (Frontend)
         working-directory: ./ve-shop-frontend
@@ -25,6 +25,8 @@ jobs:
       - name: Build Frontend
         working-directory: ./ve-shop-frontend
         run: npm run build
+        env:
+          GITHUB_PAGES: "true"
 
       - name: Deploy to VPS via SSH
         uses: appleboy/ssh-action@v0.1.10
@@ -49,4 +51,4 @@ jobs:
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./ve-shop-frontend/dist  # أو غيّر حسب اسم مجلد build عندك
+          publish_dir: ./ve-shop-frontend/dist # أو غيّر حسب اسم مجلد build عندك

--- a/ve-shop-frontend/README.md
+++ b/ve-shop-frontend/README.md
@@ -365,6 +365,7 @@ npm run preview
 VITE_API_BASE_URL=https://api.ve-shop.com
 VITE_STRIPE_PUBLISHABLE_KEY=pk_live_...
 VITE_ENVIRONMENT=production
+GITHUB_PAGES=true
 ```
 
 ## 🗺️ Development Roadmap
@@ -638,5 +639,4 @@ npm run dev
 # Build for production
 npm run build
 ```
-
 **Happy coding! 🛍️✨**

--- a/ve-shop-frontend/src/App.tsx
+++ b/ve-shop-frontend/src/App.tsx
@@ -4,6 +4,7 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { ThemeProvider } from "@/components/ui/theme-provider";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { getBasePath } from "@/lib/env";
 import { AuthProvider } from "@/contexts/AuthContext";
 import { I18nProvider } from "@/providers/I18nProvider";
 import { Suspense, lazy } from "react";
@@ -31,7 +32,11 @@ const App = () => {
               <div dir={direction} className={`${direction}`}>
                 <Toaster />
                 <Sonner />
-                <BrowserRouter>
+                {/*
+                 * Dynamically set the basename so routing works when the app
+                 * is served from the /ve-shop/ subfolder on GitHub Pages.
+                 */}
+                <BrowserRouter basename={getBasePath()}>
                   <Suspense
                     fallback={
                       <div className="py-20 flex justify-center">

--- a/ve-shop-frontend/src/components/ui/logo.tsx
+++ b/ve-shop-frontend/src/components/ui/logo.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { useTheme } from "@/components/ui/theme-provider";
 import { useLanguageStore } from "@/store/languageStore";
 import { cn } from "@/lib/utils";
+import { getBasePath } from "@/lib/env";
 
 export const Logo = ({ className = "" }) => {
   const { theme } = useTheme();
@@ -15,14 +16,19 @@ export const Logo = ({ className = "" }) => {
   };
   const { direction } = useLanguageStore();
 
-  // حدد الشعار المناسب
-  const [logoSrc, setLogoSrc] = useState(() =>
-    getCurrentTheme() === "dark" ? "/ve-logo-dark.png" : "/ve-logo-day.png"
+  // Determine the correct logo based on theme and deployment base path
+  const [logoSrc, setLogoSrc] = useState(
+    () =>
+      `${getBasePath()}${
+        getCurrentTheme() === "dark" ? "ve-logo-dark.png" : "ve-logo-day.png"
+      }`,
   );
 
   useEffect(() => {
     setLogoSrc(
-      getCurrentTheme() === "dark" ? "/ve-logo-dark.png" : "/ve-logo-day.png"
+      `${getBasePath()}${
+        getCurrentTheme() === "dark" ? "ve-logo-dark.png" : "ve-logo-day.png"
+      }`,
     );
     // فقط يحدث عند تغيير الثيم
     // eslint-disable-next-line
@@ -37,7 +43,7 @@ export const Logo = ({ className = "" }) => {
         // متجاوب (عرض أكبر بوضوح من الطول)
         "h-10 w-28 sm:h-12 sm:w-36 md:h-14 md:w-44 object-contain transition-all duration-300",
         direction === "rtl" ? "ml-2" : "mr-2",
-        className
+        className,
       )}
       draggable={false}
     />

--- a/ve-shop-frontend/src/lib/env.ts
+++ b/ve-shop-frontend/src/lib/env.ts
@@ -1,0 +1,30 @@
+// Environment helper utilities for detecting where the app is running.
+// This allows us to adjust routing basenames and API/asset URLs
+// when deployed to GitHub Pages under the /ve-shop/ subpath or when
+// running locally during development.
+
+// Returns true if the app is running on localhost.
+export const isLocalhost = () =>
+  window.location.hostname === "localhost" ||
+  window.location.hostname === "127.0.0.1";
+
+// Detects if the current page is being served from the /ve-shop subfolder,
+// which indicates a GitHub Pages deployment. A custom domain may still use
+// this path, so relying on the hostname alone isn't sufficient.
+export const isGitHubPages = () =>
+  window.location.pathname === "/ve-shop" ||
+  window.location.pathname.startsWith("/ve-shop/");
+
+// Base path for routing and assets. Only use the /ve-shop/ prefix on
+// GitHub Pages deployments. All other environments, including local
+// development and VPS production, use the root path.
+export const getBasePath = () => (isGitHubPages() ? "/ve-shop/" : "/");
+
+// Base URL for API calls. If VITE_API_BASE_URL is provided it takes
+// precedence. Otherwise fall back to a reasonable default that respects
+// the current environment.
+export const getApiBaseUrl = () => {
+  const envUrl = import.meta.env.VITE_API_BASE_URL;
+  if (envUrl) return envUrl;
+  return isLocalhost() ? "http://localhost:8000" : "/api";
+};

--- a/ve-shop-frontend/vite.config.ts
+++ b/ve-shop-frontend/vite.config.ts
@@ -4,16 +4,18 @@ import path from "path";
 import { componentTagger } from "lovable-tagger";
 
 // https://vitejs.dev/config/
+// Use a different base path only when building for GitHub Pages. This is
+// controlled via the GITHUB_PAGES environment variable so regular production
+// builds still use the root path.
 export default defineConfig(({ mode }) => ({
+  base: process.env.GITHUB_PAGES ? "/ve-shop/" : "/",
   server: {
     host: "::",
     port: 8080,
   },
-  plugins: [
-    react(),
-    mode === 'development' &&
-    componentTagger(),
-  ].filter(Boolean),
+  plugins: [react(), mode === "development" && componentTagger()].filter(
+    Boolean,
+  ),
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),


### PR DESCRIPTION
## Summary
- add `GITHUB_PAGES` env var usage in workflow
- detect GitHub Pages deployment through path checking
- only use `/ve-shop/` base when `GITHUB_PAGES` is set
- tweak API default to `/api`
- document `GITHUB_PAGES` variable in README

## Testing
- `npx prettier --check src/App.tsx src/components/ui/logo.tsx src/lib/env.ts vite.config.ts ../.github/workflows/deploy.yml`
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e1db159ec833087e5c0e6a369335a