### PR TITLE
Add example env config for frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ desktop.ini
 /ve-shop-frontend/node_modules
 /ve-shop-frontend/dist
 /ve-shop-frontend/.env*
+!/ve-shop-frontend/.env.example
 /ve-shop-frontend/coverage
 
 # ==== BACKEND: ve-shop-backend (Laravel/PHP) ====
@@ -37,6 +38,7 @@ desktop.ini
 /ve-shop-backend/storage/*.key
 /ve-shop-backend/.env
 /ve-shop-backend/.env.*
+!/ve-shop-backend/.env.example
 /ve-shop-backend/Homestead.yaml
 /ve-shop-backend/Homestead.json
 /ve-shop-backend/.vagrant

--- a/ve-shop-frontend/.env.example
+++ b/ve-shop-frontend/.env.example
@@ -1,0 +1,19 @@
+# API Configuration
+VITE_API_BASE_URL=https://your-api-endpoint.com
+VITE_API_KEY=your-api-key
+
+# Payment Gateway (Optional)
+VITE_STRIPE_PUBLISHABLE_KEY=pk_test_
+VITE_PAYPAL_CLIENT_ID=your-paypal-client-id
+
+# Analytics (Optional)
+VITE_GOOGLE_ANALYTICS_ID=GA_MEASUREMENT_ID
+
+# Feature Flags
+VITE_ENABLE_ANALYTICS=true
+VITE_ENABLE_REVIEWS=true
+VITE_ENABLE_WISHLIST=true
+
+# Deployment Base Path
+# Set this to '/' for VPS deployments or '/ve-shop/' for GitHub Pages
+VITE_BASE_PATH=/


### PR DESCRIPTION
## Summary
- include a sample environment file for the React frontend
- track example env files by updating gitignore

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686e351053108330891c68d60cea6f31