### PR TITLE
Improve RTL header layout

### DIFF
--- a/ve-shop-frontend/src/components/layout/Header.tsx
+++ b/ve-shop-frontend/src/components/layout/Header.tsx
@@ -43,13 +43,15 @@ export const Header = () => {
 
       {/* Main header */}
       <div className="container mx-auto px-2 sm:px-4 py-3 sm:py-4">
-        <div className="flex items-center justify-between gap-2 sm:gap-4 w-full">
+        <div
+          className={cn(
+            "flex items-center justify-between gap-2 sm:gap-4 w-full",
+            isRTL ? "flex-row-reverse" : "flex-row"
+          )}
+        >
           
           {/* Logo Section */}
-          <div className={cn(
-            "flex items-center gap-2 min-w-[110px] sm:min-w-[140px]",
-            isRTL ? "order-3" : "order-1"
-          )}>
+          <div className="flex items-center gap-2 min-w-[110px] sm:min-w-[140px]">
             <Button
               variant="ghost"
               className="p-0 h-auto w-auto"
@@ -61,10 +63,7 @@ export const Header = () => {
           </div>
 
           {/* Search Section */}
-          <div className={cn(
-            "flex-1 max-w-2xl mx-2 hidden md:block",
-            "order-2"
-          )}>
+          <div className="flex-1 max-w-2xl mx-2 hidden md:block">
             <div className="relative">
               <Search
                 className={cn(
@@ -84,10 +83,7 @@ export const Header = () => {
           </div>
 
           {/* Actions Section */}
-          <div className={cn(
-            "flex items-center gap-1 sm:gap-2 min-w-[100px]",
-            isRTL ? "order-1" : "order-3"
-          )}>
+          <div className="flex items-center gap-1 sm:gap-2 min-w-[100px]">
             {/* Mobile Menu - Always first for RTL */}
             <div className="md:hidden">
               <MobileMenu />

--- a/ve-shop-frontend/src/components/layout/MobileMenu.tsx
+++ b/ve-shop-frontend/src/components/layout/MobileMenu.tsx
@@ -28,6 +28,7 @@ export const MobileMenu = () => {
         </Button>
       </SheetTrigger>
       <SheetContent
+        dir={direction}
         side={direction === "rtl" ? "left" : "right"}
         className="flex flex-col gap-6 pt-10"
       >

--- a/ve-shop-frontend/src/components/ui/sheet.tsx
+++ b/ve-shop-frontend/src/components/ui/sheet.tsx
@@ -36,9 +36,9 @@ const sheetVariants = cva(
         top: "inset-x-0 top-0 border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top",
         bottom:
           "inset-x-0 bottom-0 border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
-        left: "inset-y-0 left-0 h-full w-3/4 border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm",
+        left: "inset-y-0 left-0 h-full w-full sm:w-3/4 border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm",
         right:
-          "inset-y-0 right-0 h-full w-3/4  border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm",
+          "inset-y-0 right-0 h-full w-full sm:w-3/4 border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm",
       },
     },
     defaultVariants: {


### PR DESCRIPTION
## Summary
- fix header alignment for RTL languages
- open mobile menu sheet full width on small screens
- ensure mobile menu honors text direction

## Testing
- `npm run build` *(fails: vite not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686e592711dc8330b0824a36a7a0842f